### PR TITLE
Update README.md for escript configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,22 +63,6 @@ $  cp deps/castore/priv/cacerts.pem priv/cacerts.pem
 
 Than, you'll need to configure Finch like this: 
 
-```
-children = [ 
-  {Finch,
-       name: MyFinch,
-       pools: %{
-         default: [
-           conn_opts: [
-             transport_opts: [
-               cacertfile: "priv/cacerts.pem"
-             ]
-           ]
-         ]
-       }}
-]
-```
-
 ## Telemetry
 
 Finch uses Telemetry to provide instrumentation. See the `Finch.Telemetry`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Usage in elixir CLI applications built with `mix escript.build` requires that CA
 $  cp deps/castore/priv/cacerts.pem priv/cacerts.pem
 
 Than, you'll need to configure Finch like this: 
+
 ```
 children = [ 
   {Finch,
@@ -76,7 +77,7 @@ children = [ 
          ]
        }}
 ]
-
+```
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ For any unconfigured `{scheme, host, port}`, the pool will be started the first 
 it is requested. Note pools are not automatically terminated if they are unused, so
 Finch is best suited when you are requesting a known list of static hosts.
 
+## Use in escript command line applications
+
+Usage in elixir CLI applications built with `mix escript.build` requires that CAS `cacerts.pem` file is located somewhere sensible within the root applications' tree. For  example, it can be copied from within CAStore's priv/ folder to the "root" application's priv folder. Like so (from the root path of the application): 
+```
+$  cp deps/castore/priv/cacerts.pem priv/cacerts.pem
+
+Than, you'll need to configure Finch like this: 
+```
+children = [ 
+  {Finch,
+       name: MyFinch,
+       pools: %{
+         default: [
+           conn_opts: [
+             transport_opts: [
+               cacertfile: "priv/cacerts.pem"
+             ]
+           ]
+         ]
+       }}
+]
+
+
 ## Telemetry
 
 Finch uses Telemetry to provide instrumentation. See the `Finch.Telemetry`

--- a/README.md
+++ b/README.md
@@ -58,10 +58,28 @@ Finch is best suited when you are requesting a known list of static hosts.
 ## Use in escript command line applications
 
 Usage in elixir CLI applications built with `mix escript.build` requires that CAS `cacerts.pem` file is located somewhere sensible within the root applications' tree. For  example, it can be copied from within CAStore's priv/ folder to the "root" application's priv folder. Like so (from the root path of the application): 
-```
+```bash
 $  cp deps/castore/priv/cacerts.pem priv/cacerts.pem
+```
 
-Than, you'll need to configure Finch like this: 
+Then, you'll need to configure Finch like this: 
+```elixir
+
+children = [ 
+  {Finch,
+       name: MyFinch,
+       pools: %{
+         default: [
+           conn_opts: [
+             transport_opts: [
+               cacertfile: "priv/cacerts.pem"
+             ]
+           ]
+         ]
+       }}
+]
+
+```
 
 ## Telemetry
 


### PR DESCRIPTION
When using finch within a CLI app built with mix escript.build, the standard way of using CAStore produces an error, because `Application.app_dir(:castore, "priv/cacerts.pem")`in CAStore.file_path/0 refers to the - within the escript app - unknown application CAStore. 
To circumvent this, the cacerts.pem file should be located in a folder that can be reached by escript and this folder must be referenced in the Finch configuration. This PR explains how.  