### PR TITLE
Use Error struct in one missing case

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -423,7 +423,7 @@ defmodule Finch.HTTP2.Pool do
 
     # Its possible that the request doesn't exist so we guard against that here.
     if from != nil do
-      send(from, {:error, ref, :request_timeout})
+      send(from, {:error, ref, Error.exception(:request_timeout)})
     end
 
     # If we're out of requests then we should enter the disconnected state.


### PR DESCRIPTION
This will fix the following error we see when a connection is closed and a timeout occurs:

```
Task #PID<0.21687.0> started from #PID<0.2028.0> terminating
** (FunctionClauseError) no function clause matching in Exception.message/1
    (elixir 1.12.3) lib/exception.ex:58: Exception.message(:request_timeout)
    (tesla 1.4.3) lib/tesla/adapter/finch.ex:68: Tesla.Adapter.Finch.call/2
    (internal_lib 0.6.3-8-g95f0f00) lib/internal_lib/trace.ex:71: anonymous fn/4 in InternalLib.Trace.call/3
    (opentelemetry_api 1.0.0-rc.2) src/otel_tracer_noop.erl:70: :otel_tracer_noop.with_span/5
    (tesla 1.4.3) lib/tesla/middleware/fuse.ex:86: Tesla.Middleware.Fuse.run/3
    (tesla 1.4.3) lib/tesla/middleware/retry.ex:88: Tesla.Middleware.Retry.retry/3
    (tesla 1.4.3) lib/tesla/middleware/follow_redirects.ex:46: Tesla.Middleware.FollowRedirects.redirect/3
    (oauth2 2.0.0) lib/oauth2/request.ex:36: OAuth2.Request.request/6
Function: #Function<4.38246990/0 in ...
```