### PR TITLE
Add support for Mint.UnsafeProxy connections

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -1,9 +1,9 @@
 defmodule Finch.Conn do
   @moduledoc false
 
-  alias Mint.HTTP1
-  alias Finch.Telemetry
+  alias Finch.MintHTTP1
   alias Finch.SSL
+  alias Finch.Telemetry
 
   def new(scheme, host, port, opts, parent) do
     %{
@@ -42,7 +42,7 @@ defmodule Finch.Conn do
     # force the connection to use http1 and call it in this roundabout way.
     conn_opts = Keyword.merge(conn.opts, mode: :passive, protocols: [:http1])
 
-    case Mint.HTTP.connect(conn.scheme, conn.host, conn.port, conn_opts) do
+    case MintHTTP1.connect(conn.scheme, conn.host, conn.port, conn_opts) do
       {:ok, mint} ->
         Telemetry.stop(:connect, start_time, meta)
         SSL.maybe_log_secrets(conn.scheme, conn_opts, mint)
@@ -56,8 +56,8 @@ defmodule Finch.Conn do
   end
 
   def transfer(conn, pid) do
-    case HTTP1.controlling_process(conn.mint, pid) do
-      # HTTP1.controlling_process causes a side-effect, but it doesn't actually
+    case MintHTTP1.controlling_process(conn.mint, pid) do
+      # MintHTTP1.controlling_process causes a side-effect, but it doesn't actually
       # change the conn, so we can ignore the value returned above.
       {:ok, _} -> {:ok, conn}
       {:error, error} -> {:error, conn, error}
@@ -65,7 +65,7 @@ defmodule Finch.Conn do
   end
 
   def open?(%{mint: nil}), do: false
-  def open?(%{mint: mint}), do: HTTP1.open?(mint)
+  def open?(%{mint: mint}), do: MintHTTP1.open?(mint)
 
   def idle_time(conn, unit \\ :native) do
     idle_time = System.monotonic_time() - conn.last_checkin
@@ -77,7 +77,7 @@ defmodule Finch.Conn do
   def reusable?(%{max_idle_time: max_idle_time}, idle_time), do: idle_time <= max_idle_time
 
   def set_mode(conn, mode) when mode in [:active, :passive] do
-    case HTTP1.set_mode(conn.mint, mode) do
+    case MintHTTP1.set_mode(conn.mint, mode) do
       {:ok, mint} -> {:ok, %{conn | mint: mint}}
       _ -> {:error, "Connection is dead"}
     end
@@ -86,7 +86,7 @@ defmodule Finch.Conn do
   def discard(%{mint: nil}, _), do: :unknown
 
   def discard(conn, message) do
-    case HTTP1.stream(conn.mint, message) do
+    case MintHTTP1.stream(conn.mint, message) do
       {:ok, mint, _responses} -> {:ok, %{conn | mint: mint}}
       {:error, _, reason, _} -> {:error, reason}
       :unknown -> :unknown
@@ -105,7 +105,13 @@ defmodule Finch.Conn do
     start_time = Telemetry.start(:send, metadata, extra_measurements)
 
     try do
-      case HTTP1.request(conn.mint, req.method, full_path, req.headers, stream_or_body(req.body)) do
+      case MintHTTP1.request(
+             conn.mint,
+             req.method,
+             full_path,
+             req.headers,
+             stream_or_body(req.body)
+           ) do
         {:ok, mint, ref} ->
           case maybe_stream_request_body(mint, ref, req.body, receive_timeout) do
             {:ok, mint} ->
@@ -147,7 +153,7 @@ defmodule Finch.Conn do
 
   defp maybe_stream_request_body(mint, ref, {:stream, stream}, _timeout) do
     with {:ok, mint} <- stream_request_body(mint, ref, stream) do
-      HTTP1.stream_request_body(mint, ref, :eof)
+      MintHTTP1.stream_request_body(mint, ref, :eof)
     end
   end
 
@@ -155,7 +161,7 @@ defmodule Finch.Conn do
 
   defp stream_request_body(mint, ref, stream) do
     Enum.reduce_while(stream, {:ok, mint}, fn
-      chunk, {:ok, mint} -> {:cont, HTTP1.stream_request_body(mint, ref, chunk)}
+      chunk, {:ok, mint} -> {:cont, MintHTTP1.stream_request_body(mint, ref, chunk)}
       _chunk, error -> {:halt, error}
     end)
   end
@@ -163,7 +169,7 @@ defmodule Finch.Conn do
   def close(%{mint: nil} = conn), do: conn
 
   def close(conn) do
-    {:ok, mint} = HTTP1.close(conn.mint)
+    {:ok, mint} = MintHTTP1.close(conn.mint)
     %{conn | mint: mint}
   end
 
@@ -182,7 +188,7 @@ defmodule Finch.Conn do
   end
 
   defp receive_response([], acc, fun, mint, ref, timeout) do
-    case HTTP1.recv(mint, 0, timeout) do
+    case MintHTTP1.recv(mint, 0, timeout) do
       {:ok, mint, entries} ->
         receive_response(entries, acc, fun, mint, ref, timeout)
 

--- a/lib/finch/http1/mint_http1.ex
+++ b/lib/finch/http1/mint_http1.ex
@@ -1,0 +1,74 @@
+defmodule Finch.MintHTTP1 do
+  @moduledoc false
+
+  alias Mint.HTTP1
+  alias Mint.UnsafeProxy
+
+  def connect(scheme, host, port, conn_opts) do
+    Mint.HTTP.connect(scheme, host, port, conn_opts)
+  end
+
+  def open?(%HTTP1{} = mint) do
+    HTTP1.open?(mint)
+  end
+
+  def open?(%UnsafeProxy{} = mint) do
+    UnsafeProxy.open?(mint)
+  end
+
+  def set_mode(%HTTP1{} = mint, mode) do
+    HTTP1.set_mode(mint, mode)
+  end
+
+  def set_mode(%UnsafeProxy{} = mint, mode) do
+    UnsafeProxy.set_mode(mint, mode)
+  end
+
+  def stream(%HTTP1{} = mint, message) do
+    HTTP1.stream(mint, message)
+  end
+
+  def stream(%UnsafeProxy{} = mint, message) do
+    UnsafeProxy.stream(mint, message)
+  end
+
+  def request(%HTTP1{} = mint, method, path, headers, stream_or_body) do
+    HTTP1.request(mint, method, path, headers, stream_or_body)
+  end
+
+  def request(%UnsafeProxy{} = mint, method, path, headers, stream_or_body) do
+    UnsafeProxy.request(mint, method, path, headers, stream_or_body)
+  end
+
+  def close(%HTTP1{} = mint) do
+    HTTP1.close(mint)
+  end
+
+  def close(%UnsafeProxy{} = mint) do
+    UnsafeProxy.close(mint)
+  end
+
+  def controlling_process(%HTTP1{} = mint, pid) do
+    HTTP1.controlling_process(mint, pid)
+  end
+
+  def controlling_process(%UnsafeProxy{} = mint, pid) do
+    UnsafeProxy.controlling_process(mint, pid)
+  end
+
+  def recv(%HTTP1{} = mint, byte_count, timeout) do
+    HTTP1.recv(mint, byte_count, timeout)
+  end
+
+  def recv(%UnsafeProxy{} = mint, byte_count, timeout) do
+    UnsafeProxy.recv(mint, byte_count, timeout)
+  end
+
+  def stream_request_body(%HTTP1{} = mint, ref, chunk) do
+    HTTP1.stream_request_body(mint, ref, chunk)
+  end
+
+  def stream_request_body(%UnsafeProxy{} = mint, ref, chunk) do
+    UnsafeProxy.stream_request_body(mint, ref, chunk)
+  end
+end

--- a/lib/finch/http1/mint_http1.ex
+++ b/lib/finch/http1/mint_http1.ex
@@ -1,6 +1,9 @@
 defmodule Finch.MintHTTP1 do
   @moduledoc false
 
+  # This module exists to ensure that protocol negotiation does not accidentally cause Mint to open
+  # HTTP2 connections in our HTTP1 pools.
+
   alias Mint.HTTP1
   alias Mint.UnsafeProxy
 

--- a/test/finch/http1/integration_proxy_test.exs
+++ b/test/finch/http1/integration_proxy_test.exs
@@ -1,0 +1,35 @@
+defmodule Finch.HTTP1.IntegrationProxyTest do
+  use ExUnit.Case, async: false
+
+  alias Finch.HTTP1Server
+
+  setup_all do
+    port = 4002
+
+    # Not quite a proper forward proxy server, but good enough
+    {:ok, _} = HTTP1Server.start(port)
+
+    {:ok, proxy_port: port}
+  end
+
+  test "requests HTTP through a proxy", %{proxy_port: proxy_port} do
+    start_finch(proxy_port)
+
+    assert {:ok, _} = Finch.build(:get, "http://example.com") |> Finch.request(ProxyFinch)
+  end
+
+  defp start_finch(proxy_port) do
+    start_supervised!(
+      {Finch,
+       name: ProxyFinch,
+       pools: %{
+         default: [
+           protocol: :http1,
+           conn_opts: [
+             proxy: {:http, "localhost", proxy_port, []}
+           ]
+         ]
+       }}
+    )
+  end
+end

--- a/test/finch/http1/integration_test.exs
+++ b/test/finch/http1/integration_test.exs
@@ -4,13 +4,13 @@ defmodule Finch.HTTP1.IntegrationTest do
 
   require Logger
 
-  alias Finch.HTTP1Server
+  alias Finch.HTTPS1Server
   alias Finch.TestHelper
 
   setup_all do
     port = 4001
 
-    {:ok, _} = HTTP1Server.start(port)
+    {:ok, _} = HTTPS1Server.start(port)
 
     {:ok, url: "https://localhost:#{port}"}
   end

--- a/test/support/https1_server.ex
+++ b/test/support/https1_server.ex
@@ -1,14 +1,20 @@
-defmodule Finch.HTTP1Server do
+defmodule Finch.HTTPS1Server do
   @moduledoc false
+
+  @fixtures_dir Path.expand("../fixtures", __DIR__)
 
   def start(port) do
     children = [
       Plug.Adapters.Cowboy.child_spec(
-        scheme: :http,
+        scheme: :https,
         plug: Finch.HTTP1Server.PlugRouter,
         options: [
           port: port,
           otp_app: :finch,
+          cipher_suite: :strong,
+          certfile: Path.join([@fixtures_dir, "selfsigned.pem"]),
+          keyfile: Path.join([@fixtures_dir, "selfsigned_key.pem"]),
+          alpn_preferred_protocols: :undefined,
           protocol_options: [
             idle_timeout: 3_000,
             request_timeout: 10_000
@@ -21,7 +27,7 @@ defmodule Finch.HTTP1Server do
   end
 end
 
-defmodule Finch.HTTP1Server.PlugRouter do
+defmodule Finch.HTTPS1Server.PlugRouter do
   @moduledoc false
 
   use Plug.Router


### PR DESCRIPTION
This adds several private proxy functions to Finch.HTTP1.Conn to dispatch to either Mint.UnsafeProxy or Mint.HTTP1. The dispatching is performed explicitly so as to better catch any changes to the underlying API with compiler errors/warnings where possible.

I don't think this completely finishes the scope of what was being discussed in #157 but it clears up the runtime errors and now handles HTTP 1.1 proxy configuration.