### PR TITLE
Fix and improve Telemetry doc formatting

### DIFF
--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -166,7 +166,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :conn_max_idle_time_exceeded] - Executed if a connection was discarded because the conn_max_idle_time had been reached.
+  * `[:finch, :conn_max_idle_time_exceeded] - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
 
     #### Measurements:
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
@@ -177,9 +177,9 @@ defmodule Finch.Telemetry do
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :max_idle_time_exceeded] - Executed if a connection was discarded because the max_idle_time had been reached.
+  * `[:finch, :max_idle_time_exceeded]` - Executed if a connection was discarded because the `max_idle_time` had been reached.
 
-    Deprecated use :conn_max_idle_time_exceeded event instead.
+    Deprecated use `:conn_max_idle_time_exceeded` event instead.
 
     #### Measurements:
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
@@ -190,7 +190,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :pool_max_idle_time_exceeded]` - Executed if a pool was terminated because the pool_max_idle_time has been reached. There are no measurements provided with this event.
+  * `[:finch, :pool_max_idle_time_exceeded]` - Executed if a pool was terminated because the `pool_max_idle_time` has been reached. There are no measurements provided with this event.
 
     #### Metadata
 


### PR DESCRIPTION
- Fixed a missing ending backtick which broke formatting
- Used backticks to highlight code items for clarity