### PR TITLE
Improve formatting of Telemetry docs (part 2)

### DIFF
--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -2,7 +2,7 @@ defmodule Finch.Telemetry do
   @moduledoc """
   Telemetry integration.
 
-  Unless specified, all time's are in `:native` units.
+  Unless specified, all times are in `:native` units.
 
   Finch executes the following events:
 

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -6,40 +6,46 @@ defmodule Finch.Telemetry do
 
   Finch executes the following events:
 
-  * `[:finch, :request, :start]` - Executed when `Finch.request/3` or `Finch.stream/5` is called.
+  ### Request Start
 
-    #### Measurements
+  `[:finch, :request, :start]` - Executed when `Finch.request/3` or `Finch.stream/5` is called.
 
-      * `:system_time` - The system time.
+  #### Measurements
 
-    #### Metadata
+    * `:system_time` - The system time.
 
-      * `:name` - The name of the Finch instance.
-      * `:request` - The request (`Finch.Request`).
-
-  * `[:finch, :request, :stop]` - Executed after `Finch.request/3` or `Finch.stream/5` ended.
-
-    #### Measurements
-
-    * `:duration` - Duration how long the request took.
-
-    #### Metadata
+  #### Metadata
 
     * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
-    * `:result` - The result of the operation. In case of `Finch.stream/5` this is
-      `{:ok, acc} | {:error, Exception.t()}`, where `acc` is the accumulator result of the
-      reducer passed in `Finch.stream/5`. In case of `Finch.request/3` this is
-      `{:ok, Finch.Response.t()} | {:error, Exception.t()}`.
 
-  * `[:finch, :request, :exception]` - Executed when an exception occurs while executing
+  ### Request Stop
+
+  `[:finch, :request, :stop]` - Executed after `Finch.request/3` or `Finch.stream/5` ended.
+
+  #### Measurements
+
+  * `:duration` - Duration how long the request took.
+
+  #### Metadata
+
+  * `:name` - The name of the Finch instance.
+  * `:request` - The request (`Finch.Request`).
+  * `:result` - The result of the operation. In case of `Finch.stream/5` this is
+    `{:ok, acc} | {:error, Exception.t()}`, where `acc` is the accumulator result of the
+    reducer passed in `Finch.stream/5`. In case of `Finch.request/3` this is
+    `{:ok, Finch.Response.t()} | {:error, Exception.t()}`.
+
+  ### Request Exception
+
+  `[:finch, :request, :exception]` - Executed when an exception occurs while executing
     `Finch.request/3` or `Finch.stream/5`.
 
-    #### Measurements
+  #### Measurements
 
     * `:duration` - The time it took since the start before raising the exception.
 
-    #### Metadata
+  #### Metadata
 
     * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
@@ -47,167 +53,196 @@ defmodule Finch.Telemetry do
     * `:reason` - Error description or error data.
     * `:stacktrace` - The stacktrace.
 
-  * `[:finch, :queue, :start]` - Executed before checking out a connection from the pool.
+  ### Queue Start
 
-    #### Measurements
+  `[:finch, :queue, :start]` - Executed before checking out a connection from the pool.
 
-      * `:system_time` - The system time.
+  #### Measurements
 
-    #### Metadata
+    * `:system_time` - The system time.
 
-      * `:pool` - The pool's pid.
-      * `:request` - The request (`Finch.Request`).
-
-  * `[:finch, :queue, :stop]` - Executed after a connection is retrieved from the pool.
-
-    #### Measurements
-
-    * `:duration` - Duration to check out a pool connection.
-    * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
-
-    #### Metadata
+  #### Metadata
 
     * `:pool` - The pool's pid.
     * `:request` - The request (`Finch.Request`).
 
-  * `[:finch, :queue, :exception]` - Executed if checking out a connection throws an exception.
+  ### Queue Stop
 
-    #### Measurements
+  `[:finch, :queue, :stop]` - Executed after a connection is retrieved from the pool.
+
+  #### Measurements
+
+    * `:duration` - Duration to check out a pool connection.
+    * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
+
+  #### Metadata
+
+    * `:pool` - The pool's pid.
+    * `:request` - The request (`Finch.Request`).
+
+  ### Queue Exception
+
+  `[:finch, :queue, :exception]` - Executed if checking out a connection throws an exception.
+
+  #### Measurements
 
     * `:duration` - The time it took before raising an exception
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
     * `:kind` - The type of exception.
     * `:reason` - Error description or error data.
     * `:stacktrace` - The stacktrace.
 
-  * `[:finch, :connect, :start]` - Executed before opening a new connection.
+  ### Connect Start
+
+  `[:finch, :connect, :start]` - Executed before opening a new connection.
     If a connection is being re-used this event will *not* be executed.
 
-    #### Measurements
+  #### Measurements
 
     * `:system_time` - The system time.
 
-    #### Metadata
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :connect, :stop]` - Executed after a connection is opened.
+  ### Connect Stop
 
-    #### Measurements
+  `[:finch, :connect, :stop]` - Executed after a connection is opened.
+
+  #### Measurements
 
     * `:duration` - Duration to connect to the host.
 
-    #### Metadata
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
     * `:error` - This value is optional. It includes any errors that occurred while opening the connection.
 
-  * `[:finch, :send, :start]` - Executed before sending a request.
+  ### Send Start
 
-    #### Measurements
+  `[:finch, :send, :start]` - Executed before sending a request.
+
+  #### Measurements
 
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
 
-  * `[:finch, :send, :stop]` - Executed after a request is finished.
+  ### Send Stop
 
-    #### Measurements
+  `[:finch, :send, :stop]` - Executed after a request is finished.
+
+  #### Measurements
 
     * `:duration` - Duration to make the request.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
     * `:error` - This value is optional. It includes any errors that occurred while making the request.
 
-  * `[:finch, :recv, :start]` - Executed before receiving the response.
+  ### Receive Start
 
-    #### Measurements
+  `[:finch, :recv, :start]` - Executed before receiving the response.
+
+  #### Measurements
 
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
 
-  * `[:finch, :recv, :stop]` - Executed after a response has been fully received.
+  ### Receive Start
 
-    #### Measurements
+  `[:finch, :recv, :stop]` - Executed after a response has been fully received.
+
+  #### Measurements
 
     * `:duration` - Duration to receive the response.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
     * `:status` - The response status (`Mint.Types.status()`).
     * `:headers` - The response headers (`Mint.Types.headers()`).
     * `:error` - This value is optional. It includes any errors that occurred while receiving the response.
 
-  * `[:finch, :recv, :exception]` - Executed if an exception is thrown before the response has
+  ### Receive Exception
+
+  `[:finch, :recv, :exception]` - Executed if an exception is thrown before the response has
     been fully received.
 
-    #### Measurements
+  #### Measurements
 
     * `:duration` - The time it took before raising an exception
 
-    #### Metadata
+  #### Metadata
 
     * `:request` - The request (`Finch.Request`).
     * `:kind` - The type of exception.
     * `:reason` - Error description or error data.
     * `:stacktrace` - The stacktrace.
 
-  * `[:finch, :reused_connection]` - Executed if an existing connection is reused. There are no measurements provided with this event.
+  ### Reused Connection
 
-    #### Metadata
+
+  `[:finch, :reused_connection]` - Executed if an existing connection is reused. There are no measurements provided with this event.
+
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :conn_max_idle_time_exceeded]` - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
+  ### Conn Max Idle Time Exceeded
 
-    #### Measurements
+  `[:finch, :conn_max_idle_time_exceeded]` - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
+
+  #### Measurements
 
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :max_idle_time_exceeded]` - Executed if a connection was discarded because the `max_idle_time` had been reached.
+  ### Max Idle Time Exceeded
 
-    Deprecated use `:conn_max_idle_time_exceeded` event instead.
+  `[:finch, :max_idle_time_exceeded]` - Executed if a connection was discarded because the `max_idle_time` had been reached.
 
-    #### Measurements
+  Deprecated use `:conn_max_idle_time_exceeded` event instead.
+
+  #### Measurements
 
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :pool_max_idle_time_exceeded]` - Executed if a pool was terminated because the `pool_max_idle_time` has been reached. There are no measurements provided with this event.
+  ### Pool Max Idle Time Exceeded
 
-    #### Metadata
+  `[:finch, :pool_max_idle_time_exceeded]` - Executed if a pool was terminated because the `pool_max_idle_time` has been reached. There are no measurements provided with this event.
+
+  #### Metadata
 
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -179,7 +179,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
-  * `[:finch, :conn_max_idle_time_exceeded] - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
+  * `[:finch, :conn_max_idle_time_exceeded]` - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
 
     #### Measurements
 

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -12,7 +12,7 @@ defmodule Finch.Telemetry do
 
       * `:system_time` - The system time.
 
-    #### Metadata:
+    #### Metadata
 
       * `:name` - The name of the Finch instance.
       * `:request` - The request (`Finch.Request`).
@@ -53,7 +53,7 @@ defmodule Finch.Telemetry do
 
       * `:system_time` - The system time.
 
-    #### Metadata:
+    #### Metadata
 
       * `:pool` - The pool's pid.
       * `:request` - The request (`Finch.Request`).
@@ -99,7 +99,7 @@ defmodule Finch.Telemetry do
     #### Measurements
     * `:duration` - Duration to connect to the host.
 
-    #### Metadata:
+    #### Metadata
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
@@ -107,39 +107,39 @@ defmodule Finch.Telemetry do
 
   * `[:finch, :send, :start]` - Executed before sending a request.
 
-    #### Measurements:
+    #### Measurements
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata:
+    #### Metadata
     * `:request` - The request (`Finch.Request`).
 
   * `[:finch, :send, :stop]` - Executed after a request is finished.
 
-    #### Measurements:
+    #### Measurements
     * `:duration` - Duration to make the request.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata:
+    #### Metadata
     * `:request` - The request (`Finch.Request`).
     * `:error` - This value is optional. It includes any errors that occurred while making the request.
 
   * `[:finch, :recv, :start]` - Executed before receiving the response.
 
-    #### Measurements:
+    #### Measurements
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata:
+    #### Metadata
     * `:request` - The request (`Finch.Request`).
 
   * `[:finch, :recv, :stop]` - Executed after a response has been fully received.
 
-    #### Measurements:
+    #### Measurements
     * `:duration` - Duration to receive the response.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
-    #### Metadata:
+    #### Metadata
     * `:request` - The request (`Finch.Request`).
     * `:status` - The response status (`Mint.Types.status()`).
     * `:headers` - The response headers (`Mint.Types.headers()`).
@@ -161,14 +161,14 @@ defmodule Finch.Telemetry do
 
   * `[:finch, :reused_connection]` - Executed if an existing connection is reused. There are no measurements provided with this event.
 
-    #### Metadata:
+    #### Metadata
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
 
   * `[:finch, :conn_max_idle_time_exceeded] - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
 
-    #### Measurements:
+    #### Measurements
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
@@ -181,7 +181,7 @@ defmodule Finch.Telemetry do
 
     Deprecated use `:conn_max_idle_time_exceeded` event instead.
 
-    #### Measurements:
+    #### Measurements
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -87,9 +87,11 @@ defmodule Finch.Telemetry do
     If a connection is being re-used this event will *not* be executed.
 
     #### Measurements
+
     * `:system_time` - The system time.
 
     #### Metadata
+
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
@@ -97,9 +99,11 @@ defmodule Finch.Telemetry do
   * `[:finch, :connect, :stop]` - Executed after a connection is opened.
 
     #### Measurements
+
     * `:duration` - Duration to connect to the host.
 
     #### Metadata
+
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
@@ -108,38 +112,46 @@ defmodule Finch.Telemetry do
   * `[:finch, :send, :start]` - Executed before sending a request.
 
     #### Measurements
+
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
+
     * `:request` - The request (`Finch.Request`).
 
   * `[:finch, :send, :stop]` - Executed after a request is finished.
 
     #### Measurements
+
     * `:duration` - Duration to make the request.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
+
     * `:request` - The request (`Finch.Request`).
     * `:error` - This value is optional. It includes any errors that occurred while making the request.
 
   * `[:finch, :recv, :start]` - Executed before receiving the response.
 
     #### Measurements
+
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
+
     * `:request` - The request (`Finch.Request`).
 
   * `[:finch, :recv, :stop]` - Executed after a response has been fully received.
 
     #### Measurements
+
     * `:duration` - Duration to receive the response.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
+
     * `:request` - The request (`Finch.Request`).
     * `:status` - The response status (`Mint.Types.status()`).
     * `:headers` - The response headers (`Mint.Types.headers()`).
@@ -162,6 +174,7 @@ defmodule Finch.Telemetry do
   * `[:finch, :reused_connection]` - Executed if an existing connection is reused. There are no measurements provided with this event.
 
     #### Metadata
+
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
@@ -169,6 +182,7 @@ defmodule Finch.Telemetry do
   * `[:finch, :conn_max_idle_time_exceeded] - Executed if a connection was discarded because the `conn_max_idle_time` had been reached.
 
     #### Measurements
+
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
@@ -182,6 +196,7 @@ defmodule Finch.Telemetry do
     Deprecated use `:conn_max_idle_time_exceeded` event instead.
 
     #### Measurements
+
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
@@ -197,8 +212,6 @@ defmodule Finch.Telemetry do
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - the port to connect on.
-
-
   """
 
   @doc false


### PR DESCRIPTION
- Fix the other missing backtick I didn't spot in #185
- Remove colons and add newlines for consistency thoughout