### PR TITLE
remove status and headers metadata from [:finch, :recv, :stop] event

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -169,8 +169,7 @@ defmodule Finch.Conn do
 
   defp handle_response(response, conn, metadata, start_time, extra_measurements) do
     case response do
-      {:ok, mint, {status, headers, _} = acc} ->
-        metadata = Map.merge(metadata, %{status: status, headers: headers})
+      {:ok, mint, acc} ->
         Telemetry.stop(:recv, start_time, metadata, extra_measurements)
         {:ok, %{conn | mint: mint}, acc}
 

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -177,8 +177,6 @@ defmodule Finch.Telemetry do
   #### Metadata
 
     * `:request` - The request (`Finch.Request`).
-    * `:status` - The response status (`Mint.Types.status()`).
-    * `:headers` - The response headers (`Mint.Types.headers()`).
     * `:error` - This value is optional. It includes any errors that occurred while receiving the response.
 
   ### Receive Exception

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -567,6 +567,17 @@ defmodule FinchTest do
                |> Finch.stream(finch_name, acc, fun)
     end
 
+    test "with atom accumulator", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+      expect_any(bypass)
+
+      fun = fn _msg, :ok -> :ok end
+
+      assert {:ok, :ok} =
+               Finch.build(:get, endpoint(bypass))
+               |> Finch.stream(finch_name, :ok, fun)
+    end
+
     test "successful post request, with query string and string request body",
          %{bypass: bypass, finch_name: finch_name} do
       start_supervised!({Finch, name: finch_name})


### PR DESCRIPTION
We cannot reliably extract them from the stream accumulator since it can take any shape the user desires.

Closes #192 