### PR TITLE
Return `Finch.Error` instead of propagating `Mint.TransportError`

### DIFF
--- a/lib/finch/error.ex
+++ b/lib/finch/error.ex
@@ -2,7 +2,7 @@ defmodule Finch.Error do
   @moduledoc """
   An HTTP error.
 
-  This exception struct is used to represent errors of all sorts for the HTTP/2 protocol.
+  This exception struct is used to represent errors of all sorts.
   """
 
   @type t() :: %__MODULE__{reason: atom()}

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -498,7 +498,7 @@ defmodule FinchTest do
     test "returns error when requesting bad address", %{finch_name: finch_name} do
       start_supervised!({Finch, name: finch_name})
 
-      assert {:error, %{reason: :nxdomain}} =
+      assert {:error, %Finch.Error{reason: :nxdomain}} =
                Finch.build(:get, "http://idontexist.wat") |> Finch.request(finch_name)
     end
 


### PR DESCRIPTION
While I was giving a try to solve https://github.com/sneako/finch/issues/186 I found this unit of changes might be independently testable and reviewable. So let me submit this first. What do you think?

---

Replaced `with` with `case` to roughly catch error.
This can at least stop propagating `Mint.TransportError`.

For other sorts of errors, it just returns themselves.
Since `Finch.Error` wants the reason given to be atom,
I've refrained from trying to pack everything into `Finch.Error`.

before:

```elixir
iex(2)> Finch.build(:get, "https://") |> Finch.request(MyFinch)
{:error,
 %Mint.TransportError{
   reason: {:options,
    {:socket_options,
     [
       nodelay: true,
       keepalive: true,
       packet_size: 0,
       packet: 0,
       header: 0,
       active: false,
       mode: :binary
     ]}}
 }}
```

after:

```elixir
iex(29)> Finch.build(:get, "https://") |> Finch.request(MyFinch)
{:error,
 %Finch.Error{
   reason: {:options,
    {:socket_options,
     [
       nodelay: true,
       keepalive: true,
       packet_size: 0,
       packet: 0,
       header: 0,
       active: false,
       mode: :binary
     ]}}
 }}
```