### PR TITLE
Update request.ex

### DIFF
--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -117,7 +117,7 @@ defmodule Finch.Request do
 
   @doc false
   def parse_url(url) when is_binary(url) do
-    url |> URI.parse() |> parse_url()
+    url |> String.trim() |> URI.parse() |> parse_url()
   end
 
   def parse_url(%URI{} = parsed_uri) do


### PR DESCRIPTION
Strip spaces at the end of url

When not removing it, it ocurrs the Mint error `{:invalid_request_target, target}`, see https://hexdocs.pm/mint/Mint.HTTP1.html#types