### PR TITLE
Define Finch.child_spec/1

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -107,7 +107,7 @@ defmodule Finch do
   #{NimbleOptions.docs(@pool_config_schema)}
   """
   def start_link(opts) do
-    name = Keyword.get(opts, :name) || raise ArgumentError, "must supply a name"
+    name = finch_name!(opts)
     pools = Keyword.get(opts, :pools, []) |> pool_options!()
     {default_pool_config, pools} = Map.pop(pools, :default)
 
@@ -122,6 +122,13 @@ defmodule Finch do
     Supervisor.start_link(__MODULE__, config, name: supervisor_name(name))
   end
 
+  def child_spec(opts) do
+    %{
+      id: finch_name!(opts),
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
   @impl true
   def init(config) do
     children = [
@@ -131,6 +138,10 @@ defmodule Finch do
     ]
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  defp finch_name!(opts) do
+    Keyword.get(opts, :name) || raise(ArgumentError, "must supply a name")
   end
 
   defp pool_options!(pools) do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -23,6 +23,12 @@ defmodule FinchTest do
                ":max_idle_time is deprecated. Use :conn_max_idle_time instead."
              )
     end
+
+    test "multiple instances can be started under a single supervisor without additional configuration",
+         %{finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+      start_supervised!({Finch, name: String.to_atom("#{finch_name}2")})
+    end
   end
 
   describe "pool configuration" do


### PR DESCRIPTION
By default it will set the child_spec :id to the Finch :name. This
allows multiple Finch instances to be started under a single supervisor
without any additional configuration.

See https://github.com/phoenixframework/phoenix/issues/4876#issuecomment-1193323397 for discussion.

cc @wojtekmach 