### PR TITLE
Allow using with castore 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Finch.MixProject do
   defp deps do
     [
       {:mint, "~> 1.3"},
-      {:castore, "~> 0.1"},
+      {:castore, "~> 0.1 or ~> 1.0"},
       {:nimble_pool, "~> 0.2.6"},
       {:nimble_options, "~> 0.4"},
       {:telemetry, "~> 0.4 or ~> 1.0"},


### PR DESCRIPTION
CAStore 1.0 was released with no major API changes.

Alternatively the requirement could be just bumped to `1.0`.

I didn't update the `mix.lock` file, because `mint` also depends on `castore`, and because of some [changes](https://github.com/elixir-mint/mint/pull/331) tests would fail here after updating `mint`.