### PR TITLE
Add request! function

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,7 +18,7 @@ jobs:
              otp: '25.x'
            lint: lint
 
-   runs-on: ubuntu-18.04
+   runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v2
      - uses: actions/cache@v2

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -354,9 +354,8 @@ defmodule Finch do
   @spec request!(Request.t(), name(), keyword()) ::
           Response.t()
   def request!(%Request{} = req, name, opts \\ []) do
-    with {:ok, resp} <- request(req, name, opts) do
-      resp
-    else
+    case request(req, name, opts) do
+      {:ok, resp} -> resp
       {:error, exception} -> raise exception
     end
   end

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -332,6 +332,19 @@ defmodule Finch do
     end
   end
 
+  # Catch-all for backwards compatibility below
+  def request(name, method, url) do
+    request(name, method, url, [])
+  end
+
+  @doc false
+  def request(name, method, url, headers, body \\ nil, opts \\ []) do
+    IO.warn("Finch.request/6 is deprecated, use Finch.build/5 + Finch.request/3 instead")
+
+    build(method, url, headers, body)
+    |> request(name, opts)
+  end
+
   @doc """
   Sends an HTTP request and returns a `Finch.Response` struct
   or raises an exception in case of failure.
@@ -346,18 +359,5 @@ defmodule Finch do
     else
       {:error, exception} -> raise exception
     end
-  end
-
-  # Catch-all for backwards compatibility below
-  def request(name, method, url) do
-    request(name, method, url, [])
-  end
-
-  @doc false
-  def request(name, method, url, headers, body \\ nil, opts \\ []) do
-    IO.warn("Finch.request/6 is deprecated, use Finch.build/5 + Finch.request/3 instead")
-
-    build(method, url, headers, body)
-    |> request(name, opts)
   end
 end

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -332,6 +332,22 @@ defmodule Finch do
     end
   end
 
+  @doc """
+  Sends an HTTP request and returns a `Finch.Response` struct
+  or raises an exception in case of failure.
+
+  See `request/3` for more detailed information.
+  """
+  @spec request!(Request.t(), name(), keyword()) ::
+          Response.t()
+  def request!(%Request{} = req, name, opts \\ []) do
+    with {:ok, resp} <- request(req, name, opts) do
+      resp
+    else
+      {:error, exception} -> raise exception
+    end
+  end
+
   # Catch-all for backwards compatibility below
   def request(name, method, url) do
     request(name, method, url, [])

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -542,14 +542,14 @@ defmodule FinchTest do
 
       assert %{status: 200} =
                Finch.build(:get, endpoint(bypass, "?" <> query_string))
-               |> Finch.request(finch_name)
+               |> Finch.request!(finch_name)
     end
 
     test "raises exception on bad request", %{finch_name: finch_name} do
       start_supervised!({Finch, name: finch_name})
 
-      assert_raise(Exception, fn ->
-        Finch.build(:get, "http://idontexist.wat") |> Finch.request(finch_name)
+      assert_raise(Mint.TransportError, fn ->
+        Finch.build(:get, "http://idontexist.wat") |> Finch.request!(finch_name)
       end)
     end
   end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -530,6 +530,30 @@ defmodule FinchTest do
     end
   end
 
+  describe "request!/3" do
+    test "returns response on successful request", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+      query_string = "query=value"
+
+      Bypass.expect_once(bypass, "GET", "/", fn conn ->
+        assert conn.query_string == query_string
+        Plug.Conn.send_resp(conn, 200, "OK")
+      end)
+
+      assert %{status: 200} =
+               Finch.build(:get, endpoint(bypass, "?" <> query_string))
+               |> Finch.request(finch_name)
+    end
+
+    test "raises exception on bad request", %{finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+
+      assert_raise(Exception, fn ->
+        Finch.build(:get, "http://idontexist.wat") |> Finch.request(finch_name)
+      end)
+    end
+  end
+
   describe "connection options" do
     test "are passed through to the conn", %{bypass: bypass} do
       expect_any(bypass)


### PR DESCRIPTION
There are some cases where I want to raise an exception on request failure. Instead of writing the `with` block every time or writing a helper function in my own code, it would be convenient to have a bang variation of `request`.

Let me know what you think. If this is accepted, it would be great if you could also cut a release after merging so I could start using the new function. Thanks!