### PR TITLE
Fully qualify call to request function

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -354,7 +354,7 @@ defmodule Finch do
   @spec request!(Request.t(), name(), keyword()) ::
           Response.t()
   def request!(%Request{} = req, name, opts \\ []) do
-    case request(req, name, opts) do
+    case Finch.request(req, name, opts) do
       {:ok, resp} -> resp
       {:error, exception} -> raise exception
     end


### PR DESCRIPTION
In `request!`, call `request` using the module name.

This fixes cases where application code calls `request!` while test code mocks `request`. In those cases, `request!` would call the original, unmocked `request`, leading to unexpected behavior. For example, using an ExVCR cassette on code that calls `request!` won't get the cassette response. By using the fully qualified module name, `request!` will call the mocked `request` instead.