### PR TITLE
http/2: reply to cancel requests in disconnected state

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -252,8 +252,8 @@ defmodule Finch.HTTP2.Pool do
   end
 
   # Ignore cancel requests if we are disconnected
-  def disconnected({:call, _from}, {:cancel, _ref}, _data) do
-    :keep_state_and_data
+  def disconnected({:call, from}, {:cancel, _ref}, _data) do
+    {:keep_state_and_data, {:reply, from, {:error, Error.exception(:disconnected)}}}
   end
 
   # We cancel all request timeouts as soon as we enter the :disconnected state, but


### PR DESCRIPTION
Closes #213 

By replying with this error, the client will no longer hang when the conditions described in the issue are met.

Sorry for the delay @Goose97. I tested this change with your bug reproduction repo and can confirm that the client no longer hangs forever in this scenario.