### PR TITLE
Recursively update receive_timeout with elapsed time

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -190,8 +190,12 @@ defmodule Finch.Conn do
   defp receive_response(entries, acc, fun, mint, ref, timeout, status \\ nil, headers \\ [])
 
   defp receive_response([], acc, fun, mint, ref, timeout, status, headers) do
+    start_time = System.monotonic_time(:millisecond)
+
     case MintHTTP1.recv(mint, 0, timeout) do
       {:ok, mint, entries} ->
+        elapsed_time = System.monotonic_time(:millisecond) - start_time
+        timeout = timeout - elapsed_time
         receive_response(entries, acc, fun, mint, ref, timeout, status, headers)
 
       {:error, mint, error, _responses} ->

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -501,6 +501,28 @@ defmodule FinchTest do
                |> Finch.request(finch_name, receive_timeout: timeout * 2)
     end
 
+    test "returns error when request times out for chunked response", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+
+      timeout = 600
+
+      Bypass.expect(bypass, fn conn ->
+        conn = Plug.Conn.send_chunked(conn, 200)
+        Enum.reduce(1..5, conn, fn _, conn ->
+          Process.sleep(timeout - 100)
+          {_, conn} = Plug.Conn.chunk(conn, "chunk!")
+          conn
+        end)
+      end)
+
+      assert {:error, %{reason: :timeout}} = Finch.build(:get, endpoint(bypass))
+            |> Finch.request(finch_name, receive_timeout: timeout)
+
+      assert {:ok, %Response{}} =
+          Finch.build(:get, endpoint(bypass))
+          |> Finch.request(finch_name, receive_timeout: timeout * 10)
+    end
+
     test "returns error when requesting bad address", %{finch_name: finch_name} do
       start_supervised!({Finch, name: finch_name})
 


### PR DESCRIPTION
Solves part of issue #26 by recursively reducing the `receive_timeout` value with the elapsed time from Mint. This is only an issue present in http1 and not http2 due to the `receive -> after` code here https://github.com/sneako/finch/blob/main/lib/finch/http2/pool.ex#L132

The new test in this PR should fail in the current Finch source code as the chunked response will cause the `receive_response/8`  function to be recursively called with the same `receive_timeout`. In this case the actual time experienced by a user making a request will be several times longer than their specified `receive_timeout`. 