### PR TITLE
Emit `:send` and `:recv` telemetry for HTTP2 async requests

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -649,10 +649,10 @@ defmodule Finch.HTTP2.Pool do
          {stream, chunks} = RequestStream.next_chunk(request.stream, window),
          request = %{request | stream: stream},
          {:ok, data} <- stream_chunks(data, ref, chunks, request) do
-      {:ok, maybe_complete_request(data, ref, request)}
+      {:ok, complete_request_if_done(data, ref, request)}
     else
       :done ->
-        {:ok, maybe_complete_request(data, ref, request)}
+        {:ok, complete_request_if_done(data, ref, request)}
 
       {:error, data, reason} ->
         {_from, data} = pop_request(data, ref)
@@ -661,7 +661,7 @@ defmodule Finch.HTTP2.Pool do
     end
   end
 
-  defp maybe_complete_request(data, ref, %{stream: %{status: :done}} = request) do
+  defp complete_request_if_done(data, ref, %{stream: %{status: :done}} = request) do
     %{from: from, telemetry: telemetry} = request
     Telemetry.stop(:send, telemetry.send, telemetry.metadata)
     recv_start = Telemetry.start(:recv, telemetry.metadata)
@@ -674,7 +674,7 @@ defmodule Finch.HTTP2.Pool do
     put_in(data.requests[ref], request)
   end
 
-  defp maybe_complete_request(data, ref, request) do
+  defp complete_request_if_done(data, ref, request) do
     put_in(data.requests[ref], request)
   end
 

--- a/test/finch/http1/telemetry_test.exs
+++ b/test/finch/http1/telemetry_test.exs
@@ -384,8 +384,7 @@ defmodule Finch.HTTP1.TelemetryTest do
       to_string(finch_name),
       [
         [:finch, :send, :start],
-        [:finch, :send, :stop],
-        [:finch, :send, :exception]
+        [:finch, :send, :stop]
       ],
       handler,
       nil

--- a/test/finch/http2/telemetry_test.exs
+++ b/test/finch/http2/telemetry_test.exs
@@ -191,8 +191,7 @@ defmodule Finch.HTTP2.TelemetryTest do
       to_string(finch_name),
       [
         [:finch, :send, :start],
-        [:finch, :send, :stop],
-        [:finch, :send, :exception]
+        [:finch, :send, :stop]
       ],
       handler,
       nil

--- a/test/finch/http2/telemetry_test.exs
+++ b/test/finch/http2/telemetry_test.exs
@@ -251,6 +251,57 @@ defmodule Finch.HTTP2.TelemetryTest do
     assert_receive {^ref, :start}
     assert_receive {^ref, :stop}
 
+    request_ref = Finch.build(:get, endpoint(bypass)) |> Finch.async_request(finch_name)
+
+    assert_receive {^ref, :start}
+    assert_receive {^ref, :stop}
+    assert_receive {^request_ref, {:status, 200}}
+
+    :telemetry.detach(to_string(finch_name))
+  end
+
+  test "reports recv exceptions", %{bypass: bypass, finch_name: finch_name} do
+    parent = self()
+    ref = make_ref()
+
+    handler = fn event, measurements, meta, _config ->
+      case event do
+        [:finch, :recv, :start] ->
+          send(parent, {ref, :start})
+
+        [:finch, :recv, :exception] ->
+          assert is_integer(measurements.duration)
+          assert %Finch.Request{} = meta.request
+          assert meta.kind == :exit
+          assert meta.reason == :cancel
+          assert meta.stacktrace != nil
+          send(parent, {ref, :exception})
+
+        _ ->
+          flunk("Unknown event")
+      end
+    end
+
+    :telemetry.attach_many(
+      to_string(finch_name),
+      [
+        [:finch, :recv, :start],
+        [:finch, :recv, :exception]
+      ],
+      handler,
+      nil
+    )
+
+    spawn(fn ->
+      Finch.build(:get, endpoint(bypass))
+      |> Finch.stream(finch_name, :ok, fn _, _ ->
+        exit(:cancel)
+      end)
+    end)
+
+    assert_receive {^ref, :start}
+    assert_receive {^ref, :exception}
+
     :telemetry.detach(to_string(finch_name))
   end
 end

--- a/test/finch/http2/telemetry_test.exs
+++ b/test/finch/http2/telemetry_test.exs
@@ -204,6 +204,12 @@ defmodule Finch.HTTP2.TelemetryTest do
     assert_receive {^ref, :start}
     assert_receive {^ref, :stop}
 
+    request_ref = Finch.build(:get, endpoint(bypass)) |> Finch.async_request(finch_name)
+
+    assert_receive {^ref, :start}
+    assert_receive {^ref, :stop}
+    assert_receive {^request_ref, {:status, 200}}
+
     :telemetry.detach(to_string(finch_name))
   end
 


### PR DESCRIPTION
Addresses #229.