### PR TITLE
Fix calls to deprecated Logger.warn/2

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: "1.7.4"
+              elixir: "1.11.4"
               otp: "22.x"
           - pair:
               elixir: "1.14.5"

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -329,7 +329,7 @@ defmodule Finch.HTTP2.Pool do
         end
 
       :unknown ->
-        Logger.warn(["Received unknown message: ", inspect(message)])
+        Logger.warning(["Received unknown message: ", inspect(message)])
         :keep_state_and_data
     end
   end
@@ -437,7 +437,7 @@ defmodule Finch.HTTP2.Pool do
         end
 
       :unknown ->
-        Logger.warn(["Received unknown message: ", inspect(message)])
+        Logger.warning(["Received unknown message: ", inspect(message)])
         :keep_state_and_data
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Finch.MixProject do
     [
       app: :finch,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.11",
       description: "An HTTP client focused on performance.",
       package: package(),
       docs: docs(),


### PR DESCRIPTION
I'm not sure if this is the right way. Maybe it's also possible to bump the minimum Elixir version to 1.11? But I guess that would be a breaking change :/