### PR TITLE
Set MIX_ENV=test on CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,9 @@ on:
       - main
 jobs:
   mix_test:
+    runs-on: ubuntu-20.04
+    env:
+      MIX_ENV: test
     strategy:
       fail-fast: false
       matrix:
@@ -17,8 +20,6 @@ jobs:
               elixir: "1.15.1"
               otp: "25.x"
             lint: lint
-
-    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
We have `mix deps.compile` and `mix compile` steps and before this patch
they were running in the default env, :dev, resulting in unnecessary
compilations.
