### PR TITLE
Split trailers from headers

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -312,7 +312,7 @@ defmodule Finch.Conn do
               mint,
               ref,
               timeout,
-              :trailers,
+              fields,
               resp_metadata
             )
 

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -298,9 +298,9 @@ defmodule Finch.Conn do
       {:headers, ^ref, value} ->
         resp_metadata =
           if fields == :headers do
-            %{resp_metadata | headers: value}
+            update_in(resp_metadata.headers, &(&1 ++ value))
           else
-            %{resp_metadata | trailers: value}
+            update_in(resp_metadata.trailers, &(&1 ++ value))
           end
 
         case fun.({fields, value}, acc) do

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -117,7 +117,20 @@ defmodule Finch.Conn do
             {:ok, mint} ->
               Telemetry.stop(:send, start_time, metadata, extra_measurements)
               start_time = Telemetry.start(:recv, metadata, extra_measurements)
-              response = receive_response([], acc, fun, mint, ref, receive_timeout)
+              resp_metadata = %{status: nil, headers: [], trailers: []}
+
+              response =
+                receive_response(
+                  [],
+                  acc,
+                  fun,
+                  mint,
+                  ref,
+                  receive_timeout,
+                  :headers,
+                  resp_metadata
+                )
+
               handle_response(response, conn, metadata, start_time, extra_measurements)
 
             {:error, mint, error} ->
@@ -175,43 +188,90 @@ defmodule Finch.Conn do
 
   defp handle_response(response, conn, metadata, start_time, extra_measurements) do
     case response do
-      {:ok, mint, acc, {status, headers}} ->
-        metadata = Map.merge(metadata, %{status: status, headers: headers})
+      {:ok, mint, acc, resp_metadata} ->
+        metadata = Map.merge(metadata, resp_metadata)
         Telemetry.stop(:recv, start_time, metadata, extra_measurements)
         {:ok, %{conn | mint: mint}, acc}
 
-      {:error, mint, error, {status, headers}} ->
-        metadata = Map.merge(metadata, %{error: error, status: status, headers: headers})
+      {:error, mint, error, resp_metadata} ->
+        metadata = Map.merge(metadata, Map.put(resp_metadata, :error, error))
         Telemetry.stop(:recv, start_time, metadata, extra_measurements)
         {:error, %{conn | mint: mint}, error}
     end
   end
 
-  defp receive_response(entries, acc, fun, mint, ref, timeout, status \\ nil, headers \\ [])
+  defp receive_response(
+         entries,
+         acc,
+         fun,
+         mint,
+         ref,
+         timeout,
+         fields,
+         resp_metadata
+       )
 
-  defp receive_response([{:done, ref} | _], acc, _fun, mint, ref, _timeout, status, headers) do
-    {:ok, mint, acc, {status, headers}}
+  defp receive_response(
+         [{:done, ref} | _],
+         acc,
+         _fun,
+         mint,
+         ref,
+         _timeout,
+         _fields,
+         resp_metadata
+       ) do
+    {:ok, mint, acc, resp_metadata}
   end
 
-  defp receive_response(_, _acc, _fun, mint, _ref, timeout, status, headers) when timeout < 0 do
-    {:error, mint, %Mint.TransportError{reason: :timeout}, {status, headers}}
+  defp receive_response(
+         _,
+         _acc,
+         _fun,
+         mint,
+         _ref,
+         timeout,
+         _fields,
+         resp_metadata
+       )
+       when timeout < 0 do
+    {:error, mint, %Mint.TransportError{reason: :timeout}, resp_metadata}
   end
 
-  defp receive_response([], acc, fun, mint, ref, timeout, status, headers) do
+  defp receive_response([], acc, fun, mint, ref, timeout, fields, resp_metadata) do
     start_time = System.monotonic_time(:millisecond)
 
     case MintHTTP1.recv(mint, 0, timeout) do
       {:ok, mint, entries} ->
         elapsed_time = System.monotonic_time(:millisecond) - start_time
         timeout = timeout - elapsed_time
-        receive_response(entries, acc, fun, mint, ref, timeout, status, headers)
+
+        receive_response(
+          entries,
+          acc,
+          fun,
+          mint,
+          ref,
+          timeout,
+          fields,
+          resp_metadata
+        )
 
       {:error, mint, error, _responses} ->
-        {:error, mint, error, {status, headers}}
+        {:error, mint, error, resp_metadata}
     end
   end
 
-  defp receive_response([entry | entries], acc, fun, mint, ref, timeout, status, headers) do
+  defp receive_response(
+         [entry | entries],
+         acc,
+         fun,
+         mint,
+         ref,
+         timeout,
+         fields,
+         resp_metadata
+       ) do
     case entry do
       {:status, ^ref, value} ->
         case fun.({:status, value}, acc) do
@@ -223,20 +283,27 @@ defmodule Finch.Conn do
               mint,
               ref,
               timeout,
-              value,
-              headers
+              fields,
+              %{resp_metadata | status: value}
             )
 
           {:halt, acc} ->
             {:ok, mint} = Mint.HTTP1.close(mint)
-            {:ok, mint, acc, {status, headers}}
+            {:ok, mint, acc, resp_metadata}
 
           other ->
             raise ArgumentError, "expected {:cont, acc} or {:halt, acc}, got: #{inspect(other)}"
         end
 
       {:headers, ^ref, value} ->
-        case fun.({:headers, value}, acc) do
+        resp_metadata =
+          if fields == :headers do
+            %{resp_metadata | headers: value}
+          else
+            %{resp_metadata | trailers: value}
+          end
+
+        case fun.({fields, value}, acc) do
           {:cont, acc} ->
             receive_response(
               entries,
@@ -245,13 +312,13 @@ defmodule Finch.Conn do
               mint,
               ref,
               timeout,
-              status,
-              headers ++ value
+              :trailers,
+              resp_metadata
             )
 
           {:halt, acc} ->
             {:ok, mint} = Mint.HTTP1.close(mint)
-            {:ok, mint, acc, {status, headers}}
+            {:ok, mint, acc, resp_metadata}
 
           other ->
             raise ArgumentError, "expected {:cont, acc} or {:halt, acc}, got: #{inspect(other)}"
@@ -267,20 +334,20 @@ defmodule Finch.Conn do
               mint,
               ref,
               timeout,
-              status,
-              headers
+              :trailers,
+              resp_metadata
             )
 
           {:halt, acc} ->
             {:ok, mint} = Mint.HTTP1.close(mint)
-            {:ok, mint, acc, {status, headers}}
+            {:ok, mint, acc, resp_metadata}
 
           other ->
             raise ArgumentError, "expected {:cont, acc} or {:halt, acc}, got: #{inspect(other)}"
         end
 
       {:error, ^ref, error} ->
-        {:error, mint, error, {status, headers}}
+        {:error, mint, error, resp_metadata}
     end
   end
 end

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -296,12 +296,7 @@ defmodule Finch.Conn do
         end
 
       {:headers, ^ref, value} ->
-        resp_metadata =
-          if fields == :headers do
-            update_in(resp_metadata.headers, &(&1 ++ value))
-          else
-            update_in(resp_metadata.trailers, &(&1 ++ value))
-          end
+        resp_metadata = update_in(resp_metadata, [fields], &(&1 ++ value))
 
         case fun.({fields, value}, acc) do
           {:cont, acc} ->

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -111,7 +111,7 @@ defmodule Finch.HTTP2.Pool do
               request_ref,
               monitor_ref,
               fail_safe_timeout,
-              :trailers
+              fields
             )
 
           {:halt, acc} ->
@@ -132,7 +132,7 @@ defmodule Finch.HTTP2.Pool do
               request_ref,
               monitor_ref,
               fail_safe_timeout,
-              fields
+              :trailers
             )
 
           {:halt, acc} ->

--- a/lib/finch/response.ex
+++ b/lib/finch/response.ex
@@ -8,12 +8,14 @@ defmodule Finch.Response do
   defstruct [
     :status,
     body: "",
-    headers: []
+    headers: [],
+    trailers: []
   ]
 
   @type t :: %Response{
           status: Mint.Types.status(),
           body: binary(),
-          headers: Mint.Types.headers()
+          headers: Mint.Types.headers(),
+          trailers: Mint.Types.headers()
         }
 end

--- a/test/finch/http1/telemetry_test.exs
+++ b/test/finch/http1/telemetry_test.exs
@@ -37,7 +37,7 @@ defmodule Finch.HTTP1.TelemetryTest do
     assert_receive {:telemetry_event, [:finch, :send, :start],
                     %{request: %{headers: [{"x-foo-request", "bar-request"}]}}}
 
-    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{headers: headers}}
+    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{headers: headers, trailers: []}}
     assert {"x-foo-response", "bar-response"} in headers
 
     :telemetry.detach(to_string(finch_name))


### PR DESCRIPTION
Ref https://github.com/wojtekmach/req/issues/230#issue-1869352131

I couldn't write an integration test for http2 given Plug has no support for trailers and it is not easy to write a fake server.

I verified it manually:

```
$ openssl req -newkey rsa:2048 -nodes -keyout server.key -x509 -days 365 -out server.crt
$ cat main.go
```

```go
package main

import (
  "log"
  "net/http"
)

func main() {
  srv := &http.Server{Addr: ":8080", Handler: http.HandlerFunc(handle)}
  log.Printf("Serving on https://0.0.0.0:8080")
  log.Fatal(srv.ListenAndServeTLS("server.crt", "server.key"))
}

func handle(w http.ResponseWriter, r *http.Request) {
  log.Printf("Got connection: %s", r.Proto)
  w.Header().Set("trailer", "x-foo")
  w.Write([]byte("Hello"))
  w.Header().Set("x-foo", "bar")
}
```

```
$ cat run.exs
```

```elixir
{:ok, _} =
  Finch.start_link(
    name: MyFinch,
    pools: %{
      default: [
        protocol: :http2,
        conn_opts: [
          transport_opts: [verify: :verify_none]
        ]
      ]
    }
  )

req = Finch.build(:get, "https://localhost:8080")
IO.inspect(Finch.request(req, MyFinch))
```

```
$ go run main.go
$ mix run run.exs
```

```elixir
{:ok,
 %Finch.Response{
   status: 200,
   body: "Hello",
   headers: [
     {"trailer", "x-foo"},
     {"content-type", "text/plain; charset=utf-8"},
     {"content-length", "5"},
     {"date", "Tue, 29 Aug 2023 09:37:39 GMT"}
   ],
   trailers: [{"x-foo", "bar"}]
 }}
```