### PR TITLE
Introduce :request_timeout option

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -399,8 +399,13 @@ defmodule Finch do
     * `:pool_timeout` - This timeout is applied when we check out a connection from the pool.
       Default value is `5_000`.
 
-    * `:receive_timeout` - The maximum time to wait for a response before returning an error.
+    * `:receive_timeout` - The maximum time to wait for each chunk to be received before returning an error.
       Default value is `15_000`.
+
+    * `:request_timeout` - The amount of time to wait for a complete response before returning an error.
+      This timeout only applies to HTTP/1, and its current implementation is a best effort timeout,
+      it does not guarantee the call will return precisely when the time has elapsed.
+      Default value is `:infinity`.
 
   """
   @spec request(Request.t(), name(), request_opts()) ::

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -29,6 +29,7 @@ defmodule Finch.HTTP1.Pool do
   def request(pool, req, acc, fun, opts) do
     pool_timeout = Keyword.get(opts, :pool_timeout, 5_000)
     receive_timeout = Keyword.get(opts, :receive_timeout, 15_000)
+    request_timeout = Keyword.get(opts, :request_timeout, :infinity)
 
     metadata = %{request: req, pool: pool}
 
@@ -42,7 +43,8 @@ defmodule Finch.HTTP1.Pool do
           Telemetry.stop(:queue, start_time, metadata, %{idle_time: idle_time})
 
           with {:ok, conn} <- Conn.connect(conn),
-               {:ok, conn, acc} <- Conn.request(conn, req, acc, fun, receive_timeout, idle_time) do
+               {:ok, conn, acc} <-
+                 Conn.request(conn, req, acc, fun, receive_timeout, request_timeout, idle_time) do
             {{:ok, acc}, transfer_if_open(conn, state, from)}
           else
             {:error, conn, error} ->


### PR DESCRIPTION
Intended to timeout a request with a chunked response after the total elapsed time has surpassed the given value. See #243.