### PR TITLE
Add finch instance name to telemetry metadata

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -360,10 +360,9 @@ defmodule Finch do
           {:ok, acc} | {:error, Exception.t()}
         when acc: term()
   def stream(%Request{} = req, name, acc, fun, opts \\ []) when is_function(fun, 2) do
-    fun =
-      fn entry, acc ->
-        {:cont, fun.(entry, acc)}
-      end
+    fun = fn entry, acc ->
+      {:cont, fun.(entry, acc)}
+    end
 
     stream_while(req, name, acc, fun, opts)
   end

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -427,7 +427,7 @@ defmodule Finch do
 
   defp __stream__(%Request{} = req, name, acc, fun, opts) do
     {pool, pool_mod} = get_pool(req, name)
-    pool_mod.request(pool, req, acc, fun, opts)
+    pool_mod.request(pool, req, acc, fun, name, opts)
   end
 
   @doc """
@@ -560,7 +560,7 @@ defmodule Finch do
   @spec async_request(Request.t(), name(), request_opts()) :: request_ref()
   def async_request(%Request{} = req, name, opts \\ []) do
     {pool, pool_mod} = get_pool(req, name)
-    pool_mod.async_request(pool, req, opts)
+    pool_mod.async_request(pool, req, name, opts)
   end
 
   @doc """

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -17,22 +17,24 @@ defmodule Finch.HTTP1.Conn do
     }
   end
 
-  def connect(%{mint: mint} = conn) when not is_nil(mint) do
+  def connect(%{mint: mint} = conn, name) when not is_nil(mint) do
     meta = %{
       scheme: conn.scheme,
       host: conn.host,
-      port: conn.port
+      port: conn.port,
+      name: name
     }
 
     Telemetry.event(:reused_connection, %{}, meta)
     {:ok, conn}
   end
 
-  def connect(%{mint: nil} = conn) do
+  def connect(%{mint: nil} = conn, name) do
     meta = %{
       scheme: conn.scheme,
       host: conn.host,
-      port: conn.port
+      port: conn.port,
+      name: name
     }
 
     start_time = Telemetry.start(:connect, meta)
@@ -98,12 +100,12 @@ defmodule Finch.HTTP1.Conn do
     end
   end
 
-  def request(%{mint: nil} = conn, _, _, _, _, _, _), do: {:error, conn, "Could not connect"}
+  def request(%{mint: nil} = conn, _, _, _, _, _, _, _), do: {:error, conn, "Could not connect"}
 
-  def request(conn, req, acc, fun, receive_timeout, request_timeout, idle_time) do
+  def request(conn, req, acc, fun, name, receive_timeout, request_timeout, idle_time) do
     full_path = Finch.Request.request_path(req)
 
-    metadata = %{request: req}
+    metadata = %{request: req, name: name}
 
     extra_measurements = %{idle_time: idle_time}
 

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -40,12 +40,13 @@ defmodule Finch.HTTP1.Pool do
   end
 
   @impl Finch.Pool
-  def request(pool, req, acc, fun, opts) do
+  def request(pool, req, acc, fun, name, opts) do
     pool_timeout = Keyword.get(opts, :pool_timeout, 5_000)
     receive_timeout = Keyword.get(opts, :receive_timeout, 15_000)
     request_timeout = Keyword.get(opts, :request_timeout, :infinity)
 
-    metadata = %{request: req, pool: pool}
+    metadata = %{request: req, pool: pool, name: name}
+
     start_time = Telemetry.start(:queue, metadata)
 
     try do
@@ -55,9 +56,9 @@ defmodule Finch.HTTP1.Pool do
         fn from, {state, conn, idle_time} ->
           Telemetry.stop(:queue, start_time, metadata, %{idle_time: idle_time})
 
-          with {:ok, conn} <- Conn.connect(conn),
+          with {:ok, conn} <- Conn.connect(conn, name),
                {:ok, conn, acc} <-
-                 Conn.request(conn, req, acc, fun, receive_timeout, request_timeout, idle_time) do
+                 Conn.request(conn, req, acc, fun, name, receive_timeout, request_timeout, idle_time) do
             {{:ok, acc}, transfer_if_open(conn, state, from)}
           else
             {:error, conn, error} ->
@@ -90,7 +91,7 @@ defmodule Finch.HTTP1.Pool do
   end
 
   @impl Finch.Pool
-  def async_request(pool, req, opts) do
+  def async_request(pool, req, name, opts) do
     owner = self()
 
     pid =
@@ -103,6 +104,7 @@ defmodule Finch.HTTP1.Pool do
                req,
                {owner, monitor, request_ref},
                &send_async_response/2,
+               name,
                opts
              ) do
           {:ok, _} -> send(owner, {request_ref, :done})

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -16,8 +16,7 @@ defmodule Finch.HTTP1.Pool do
       pool_max_idle_time,
       _start_pool_metrics?,
       _pool_idx
-    } =
-      opts
+    } = opts
 
     %{
       id: __MODULE__,
@@ -58,7 +57,16 @@ defmodule Finch.HTTP1.Pool do
 
           with {:ok, conn} <- Conn.connect(conn, name),
                {:ok, conn, acc} <-
-                 Conn.request(conn, req, acc, fun, name, receive_timeout, request_timeout, idle_time) do
+                 Conn.request(
+                   conn,
+                   req,
+                   acc,
+                   fun,
+                   name,
+                   receive_timeout,
+                   request_timeout,
+                   idle_time
+                 ) do
             {{:ok, acc}, transfer_if_open(conn, state, from)}
           else
             {:error, conn, error} ->

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -30,7 +30,7 @@ defmodule Finch.HTTP2.Pool do
   # Call the pool with the request. The pool will multiplex multiple requests
   # and stream the result set back to the calling process using `send`
   @impl Finch.Pool
-  def request(pool, request, acc, fun, opts) do
+  def request(pool, request, acc, fun, _name, opts) do
     opts = Keyword.put_new(opts, :receive_timeout, @default_receive_timeout)
     timeout = opts[:receive_timeout]
     request_ref = make_request_ref(pool)
@@ -60,7 +60,7 @@ defmodule Finch.HTTP2.Pool do
   end
 
   @impl Finch.Pool
-  def async_request(pool, req, opts) do
+  def async_request(pool, req, _name, opts) do
     opts = Keyword.put_new(opts, :receive_timeout, @default_receive_timeout)
     request_ref = make_request_ref(pool)
 

--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -9,12 +9,17 @@ defmodule Finch.Pool do
               Finch.Request.t(),
               acc,
               Finch.stream(acc),
+              Finch.name(),
               list()
-            ) ::
-              {:ok, acc} | {:error, term()}
+            ) :: {:ok, acc} | {:error, term()}
             when acc: term()
 
-  @callback async_request(pid(), Finch.Request.t(), list()) :: request_ref()
+  @callback async_request(
+              pid(),
+              Finch.Request.t(),
+              Finch.name(),
+              list()
+            ) :: request_ref()
 
   @callback cancel_async_request(request_ref()) :: :ok
 

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -109,7 +109,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.
@@ -124,7 +124,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.
@@ -136,7 +136,7 @@ defmodule Finch.Telemetry do
 
   #### Measurements
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
@@ -150,7 +150,7 @@ defmodule Finch.Telemetry do
 
   #### Measurements
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:duration` - Time taken to make the request.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
@@ -170,7 +170,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
 
   ### Receive Stop
@@ -184,7 +184,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
     * `:status` - The response status (`Mint.Types.status()`).
     * `:headers` - The response headers (`Mint.Types.headers()`).
@@ -201,7 +201,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
-    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
+    * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
     * `:kind` - The type of exception.
     * `:reason` - Error description or error data.

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -63,6 +63,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance.
     * `:pool` - The pool's PID.
     * `:request` - The request (`Finch.Request`).
 
@@ -77,6 +78,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance.
     * `:pool` - The pool's PID.
     * `:request` - The request (`Finch.Request`).
 
@@ -90,6 +92,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance.
     * `:request` - The request (`Finch.Request`).
     * `:kind` - The type of exception.
     * `:reason` - Error description or error data.
@@ -106,6 +109,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.
@@ -120,6 +124,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.
@@ -131,6 +136,7 @@ defmodule Finch.Telemetry do
 
   #### Measurements
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:system_time` - The system time.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
@@ -144,6 +150,7 @@ defmodule Finch.Telemetry do
 
   #### Measurements
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:duration` - Time taken to make the request.
     * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
@@ -163,6 +170,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:request` - The request (`Finch.Request`).
 
   ### Receive Stop
@@ -176,6 +184,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:request` - The request (`Finch.Request`).
     * `:status` - The response status (`Mint.Types.status()`).
     * `:headers` - The response headers (`Mint.Types.headers()`).
@@ -192,6 +201,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance (populated for HTTP/1 only).
     * `:request` - The request (`Finch.Request`).
     * `:kind` - The type of exception.
     * `:reason` - Error description or error data.
@@ -203,6 +213,7 @@ defmodule Finch.Telemetry do
 
   #### Metadata
 
+    * `:name` - The name of the Finch instance.
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -377,7 +377,7 @@ defmodule Finch.HTTP2.PoolTest do
           start_pool(port)
         end)
 
-      ref = Pool.async_request(pool, req, [])
+      ref = Pool.async_request(pool, req, nil, [])
 
       assert_recv_frames([headers(stream_id: stream_id)])
 
@@ -391,7 +391,7 @@ defmodule Finch.HTTP2.PoolTest do
       :timer.sleep(10)
 
       # We can't send any more requests since the connection is closed for writing.
-      ref2 = Pool.async_request(pool, req, [])
+      ref2 = Pool.async_request(pool, req, nil, [])
       assert_receive {^ref2, {:error, %Finch.Error{reason: :read_only}}}
 
       server_send_frames([
@@ -409,7 +409,7 @@ defmodule Finch.HTTP2.PoolTest do
       Process.sleep(50)
 
       # If we try to make a request now that the server shut down, we get an error.
-      ref3 = Pool.async_request(pool, req, [])
+      ref3 = Pool.async_request(pool, req, nil, [])
       assert_receive {^ref3, {:error, %Finch.Error{reason: :disconnected}}}
     end
 
@@ -421,7 +421,7 @@ defmodule Finch.HTTP2.PoolTest do
           start_pool(port)
         end)
 
-      ref = Pool.async_request(pool, req, [])
+      ref = Pool.async_request(pool, req, nil, [])
 
       assert_recv_frames([headers(stream_id: stream_id)])
 
@@ -449,7 +449,7 @@ defmodule Finch.HTTP2.PoolTest do
           start_pool(port)
         end)
 
-      ref = Pool.async_request(pool, %{req | headers: [{"foo", "bar"}]}, [])
+      ref = Pool.async_request(pool, %{req | headers: [{"foo", "bar"}]}, nil, [])
 
       assert_receive {^ref, {:error, %{reason: {:max_header_list_size_exceeded, _, _}}}}
     end
@@ -488,7 +488,7 @@ defmodule Finch.HTTP2.PoolTest do
       {:data, value}, {status, headers, body} -> {:cont, {status, headers, body <> value}}
     end
 
-    Pool.request(pool, req, acc, fun, opts)
+    Pool.request(pool, req, acc, fun, nil, opts)
   end
 
   defp start_server_and_connect_with(opts \\ [], fun) do

--- a/test/finch/http2/telemetry_test.exs
+++ b/test/finch/http2/telemetry_test.exs
@@ -35,9 +35,9 @@ defmodule Finch.HTTP2.TelemetryTest do
     assert {:ok, %{status: 200}} = Finch.request(request, finch_name)
 
     assert_receive {:telemetry_event, [:finch, :send, :start],
-                    %{request: %{headers: [{"x-foo-request", "bar-request"}]}}}
+                    %{request: %{headers: [{"x-foo-request", "bar-request"}]}, name: ^finch_name}}
 
-    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{headers: headers}}
+    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{headers: headers, name: ^finch_name}}
     assert {"x-foo-response", "bar-response"} in headers
 
     :telemetry.detach(to_string(finch_name))
@@ -58,7 +58,7 @@ defmodule Finch.HTTP2.TelemetryTest do
     request = Finch.build(:get, endpoint(bypass))
     assert {:ok, %{status: 201}} = Finch.request(request, finch_name)
 
-    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{status: 201}}
+    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{status: 201, name: ^finch_name}}
 
     :telemetry.detach(to_string(finch_name))
   end
@@ -133,6 +133,7 @@ defmodule Finch.HTTP2.TelemetryTest do
           assert is_atom(meta.scheme)
           assert is_integer(meta.port)
           assert is_binary(meta.host)
+          assert meta.name == finch_name
           send(parent, {ref, :start})
 
         [:finch, :connect, :stop] ->
@@ -140,6 +141,7 @@ defmodule Finch.HTTP2.TelemetryTest do
           assert is_atom(meta.scheme)
           assert is_integer(meta.port)
           assert is_binary(meta.host)
+          assert meta.name == finch_name
           send(parent, {ref, :stop})
 
         _ ->
@@ -175,11 +177,13 @@ defmodule Finch.HTTP2.TelemetryTest do
         [:finch, :send, :start] ->
           assert is_integer(measurements.system_time)
           assert %Finch.Request{} = meta.request
+          assert meta.name == finch_name
           send(parent, {ref, :start})
 
         [:finch, :send, :stop] ->
           assert is_integer(measurements.duration)
           assert %Finch.Request{} = meta.request
+          assert meta.name == finch_name
           send(parent, {ref, :stop})
 
         _ ->
@@ -228,6 +232,7 @@ defmodule Finch.HTTP2.TelemetryTest do
           assert %Finch.Request{} = meta.request
           assert is_integer(meta.status)
           assert is_list(meta.headers)
+          assert meta.name == finch_name
           send(parent, {ref, :stop})
 
         _ ->
@@ -275,6 +280,7 @@ defmodule Finch.HTTP2.TelemetryTest do
           assert meta.kind == :exit
           assert meta.reason == :cancel
           assert meta.stacktrace != nil
+          assert meta.name == finch_name
           send(parent, {ref, :exception})
 
         _ ->

--- a/test/finch/http2/telemetry_test.exs
+++ b/test/finch/http2/telemetry_test.exs
@@ -37,7 +37,9 @@ defmodule Finch.HTTP2.TelemetryTest do
     assert_receive {:telemetry_event, [:finch, :send, :start],
                     %{request: %{headers: [{"x-foo-request", "bar-request"}]}, name: ^finch_name}}
 
-    assert_receive {:telemetry_event, [:finch, :recv, :stop], %{headers: headers, name: ^finch_name}}
+    assert_receive {:telemetry_event, [:finch, :recv, :stop],
+                    %{headers: headers, name: ^finch_name}}
+
     assert {"x-foo-response", "bar-response"} in headers
 
     :telemetry.detach(to_string(finch_name))


### PR DESCRIPTION
Recently, my team have adopted the practice of employing distinct finch instances for handling our requests. In this commit, we aim to include the pool-id/finch-instance-name in the telemetry metadata during request processing. This addition is particularly valuable for collecting statistics on a per-finch-instance basis.

This change aligns with both @aselder 's [request](https://github.com/sneako/finch/issues/199) and @oliveigah 's [PR](https://github.com/sneako/finch/pull/248), but it's a bit more concise. Hope this makes the review and merging process quicker.