### PR TITLE
fix types, appease dialyzer

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -62,3 +62,7 @@ jobs:
       - name: Run Tests
         run: mix test --warnings-as-errors
         if: ${{ matrix.lint }}
+
+      - name: Run Dialyzer
+        run: mix dialyzer
+        if: ${{ matrix.lint }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,6 +41,7 @@ jobs:
       # Cache key based on Elixir & Erlang version (also useful when running in matrix)
       - name: Cache Dialyzer's PLT
         uses: actions/cache@v3
+        if: ${{ matrix.lint }}
         id: cache-plt
         with:
           path: plts
@@ -51,7 +52,7 @@ jobs:
 
       # Create PLTs if no cache was found
       - name: Create PLTs
-        if: ${{ matrix.dialyzer && steps.cache-plt.outputs.cache-hit != 'true' }}
+        if: ${{ matrix.lint && steps.cache-plt.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
 
       - name: Install Dependencies

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -37,6 +37,23 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
+      # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
+      # Cache key based on Elixir & Erlang version (also useful when running in matrix)
+      - name: Cache Dialyzer's PLT
+        uses: actions/cache@v3
+        id: cache-plt
+        with:
+          path: plts
+          key: |
+            ${{ runner.os }}-plt-otp${{ matrix.erlang }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-plt-otp${{ matrix.erlang }}-elixir${{ matrix.elixir }}-
+
+      # Create PLTs if no cache was found
+      - name: Create PLTs
+        if: ${{ matrix.dialyzer && steps.cache-plt.outputs.cache-hit != 'true' }}
+        run: mix dialyzer --plt
+
       - name: Install Dependencies
         run: mix deps.get
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,19 +44,17 @@ jobs:
         if: ${{ matrix.lint }}
         id: cache-plt
         with:
-          path: plts
+          path: _build/test
           key: |
-            ${{ runner.os }}-plt-otp${{ matrix.erlang }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-plt-otp${{ matrix.erlang }}-elixir${{ matrix.elixir }}-
+            ${{ runner.os }}-plt-otp${{ matrix.erlang }}-elixir${{ matrix.elixir }}
+
+      - name: Install Dependencies
+        run: mix deps.get
 
       # Create PLTs if no cache was found
       - name: Create PLTs
         if: ${{ matrix.lint && steps.cache-plt.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
-
-      - name: Install Dependencies
-        run: mix deps.get
 
       - run: mix format --check-formatted
         if: ${{ matrix.lint }}

--- a/lib/finch/http1/pool_metrics.ex
+++ b/lib/finch/http1/pool_metrics.ex
@@ -45,7 +45,7 @@ defmodule Finch.HTTP1.PoolMetrics do
 
   def maybe_add(nil, _metrics_list), do: :ok
 
-  def maybe_add(ref, metrics_list) when is_reference(ref) do
+  def maybe_add(ref, metrics_list) do
     Enum.each(metrics_list, fn {metric_name, val} ->
       :atomics.add(ref, @atomic_idx[metric_name], val)
     end)
@@ -57,7 +57,9 @@ defmodule Finch.HTTP1.PoolMetrics do
     |> get_pool_status()
   end
 
-  def get_pool_status(ref) when is_reference(ref) do
+  def get_pool_status(nil), do: {:error, :not_found}
+
+  def get_pool_status(ref) do
     %{
       pool_idx: pool_idx,
       pool_size: pool_size,
@@ -76,6 +78,4 @@ defmodule Finch.HTTP1.PoolMetrics do
 
     {:ok, result}
   end
-
-  def get_pool_status(nil), do: {:error, :not_found}
 end

--- a/lib/finch/http2/pool_metrics.ex
+++ b/lib/finch/http2/pool_metrics.ex
@@ -35,7 +35,7 @@ defmodule Finch.HTTP2.PoolMetrics do
 
   def maybe_add(nil, _metrics_list), do: :ok
 
-  def maybe_add(ref, metrics_list) when is_reference(ref) do
+  def maybe_add(ref, metrics_list) do
     Enum.each(metrics_list, fn {metric_name, val} ->
       :atomics.add(ref, @atomic_idx[metric_name], val)
     end)
@@ -47,7 +47,9 @@ defmodule Finch.HTTP2.PoolMetrics do
     |> get_pool_status()
   end
 
-  def get_pool_status(ref) when is_reference(ref) do
+  def get_pool_status(nil), do: {:error, :not_found}
+
+  def get_pool_status(ref) do
     %{
       pool_idx: pool_idx,
       in_flight_requests: in_flight_requests
@@ -63,6 +65,4 @@ defmodule Finch.HTTP2.PoolMetrics do
 
     {:ok, result}
   end
-
-  def get_pool_status(nil), do: {:error, :not_found}
 end


### PR DESCRIPTION
We need to not use `when is_reference` since the `ref` is technically an opaque type and we break that by using `is_reference` (or at least that's what i'm reading into dialyzer's output)