### PR TITLE
Remove a connection if it receives any messages while in the pool

### DIFF
--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -241,7 +241,7 @@ defmodule Finch.HTTP1.Pool do
   @impl NimblePool
   def handle_info(message, conn) do
     case Conn.discard(conn, message) do
-      {:ok, conn} -> {:ok, conn}
+      {:ok, _conn} -> {:remove, :closed}
       :unknown -> {:ok, conn}
       {:error, _error} -> {:remove, :closed}
     end


### PR DESCRIPTION
Inspired by #272 I started looking into issues where idle connections are closed but not removed from the pool. Deep down I still feel like we need a packet capture to really suss out what's going on. Even if the pool hadn't processed a message telling us the tcp socket was closed, we should get an `einval` error when we attempted to put the connection into passive mode (at least in my testing on macOS).

That said, it occurred to me that a connection sitting in the pool should not be receiving data (since its finished the requests it needed to make and is back in the pool). Thus we can treat any message intended for that connection as an error and remove it from the pool.

Let me know what you think @sneako or if I missed something here.