### PR TITLE
fix logo size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Finch](./assets/Finch_logo_onWhite.png#gh-light-mode-only)
-![Finch](./assets/Finch_logo_all-White.png#gh-dark-mode-only)
+<img alt="Finch" height="350px" src="assets/Finch_logo_onWhite.png#gh-light-mode-only">
+<img alt="Finch" height="350px" src="assets/Finch_logo_all-White.png#gh-dark-mode-only">
+
 
 [![Build Status](https://github.com/sneako/finch/workflows/CI/badge.svg?branch=main)](https://github.com/sneako/finch/actions) [![Hex pm](https://img.shields.io/hexpm/v/finch.svg?style=flat)](https://hex.pm/packages/finch) [![Hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/finch/)
 


### PR DESCRIPTION
👋 

This PR restores the logo size to the same 350px height as before [the dark/light mode change.](https://github.com/sneako/finch/commit/3c7fdb287523265a746a4b19039584cfa7c84f5c)