### PR TITLE
fix: type Finch.request_opt() was missing the :request_timeout option

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -104,7 +104,10 @@ defmodule Finch do
 
   @type scheme_host_port() :: {scheme(), host :: String.t(), port :: :inet.port_number()}
 
-  @type request_opt() :: {:pool_timeout, timeout()} | {:receive_timeout, timeout()}
+  @type request_opt() ::
+          {:pool_timeout, timeout()}
+          | {:receive_timeout, timeout()}
+          | {:request_timeout, timeout()}
 
   @typedoc """
   Options used by request functions.


### PR DESCRIPTION
Hello 👋 

First, thank you for your work on Finch 🙏

We encountered the following dyalixir error in our code:

```
lib/app/rpc.ex:352:no_return
Function post/2 has no local return.
```

Our function was only calling `Finch.build(...) |> Finch.resquest(...)` so nothing that could have raised. In this end, this was triggered because the `:request_timeout` keyword was missing from the `Finch.request_opt()` type.