### PR TITLE
Tweak Finch supervisor children strartup order

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -184,8 +184,8 @@ defmodule Finch do
   @impl true
   def init(config) do
     children = [
-      {DynamicSupervisor, name: config.supervisor_name, strategy: :one_for_one},
       {Registry, [keys: :duplicate, name: config.registry_name, meta: [config: config]]},
+      {DynamicSupervisor, name: config.supervisor_name, strategy: :one_for_one},
       {PoolManager, config}
     ]
 


### PR DESCRIPTION
Hello there, the changes aim to resolve the following issue: #277 

```elixir
ArgumentError: unknown registry: Obfuscated.FinchPool
  File "lib/registry.ex", line 1391, in Registry.info!/1
  File "lib/registry.ex", line 1007, in Registry.register/3
  File "lib/finch/http2/pool.ex", line 207, in Finch.HTTP2.Pool.init/1
  File "gen_statem.erl", line 984, in :gen_statem.init_it/6
  File "proc_lib.erl", line 241, in :proc_lib.init_p_do_apply/3
```

My comment here isn't correct – https://github.com/sneako/finch/issues/277#issuecomment-2265576904. The issue happens on shutdowns. 

---

The fix assumes that Supervisors shut down their children in reverse order. The problem with the current order is that `DynamicSupervisor` children use `Registry`. The registry goes down sooner than the dynamic supervisor does, causing the unknown registry exception.

I've tried to run the fix on the company servers, and I haven't encountered the unknown registry exception during deploys, at least so far. But maybe I've been lucky 😅 

Please let me know what do you think about the changes 🙏 