### PR TITLE
fix: include last checkout verification before idle termination

### DIFF
--- a/test/finch/http1/pool_test.exs
+++ b/test/finch/http1/pool_test.exs
@@ -125,6 +125,68 @@ defmodule Finch.HTTP1.PoolTest do
     assert [] = DynamicSupervisor.which_children(:"#{finch_name}.PoolSupervisor")
   end
 
+  # @tag capture_log: true
+  test "should not terminate if a connection is checked out", %{
+    bypass: bypass,
+    finch_name: finch_name
+  } do
+    parent = self()
+
+    start_supervised!(
+      {Finch,
+       name: finch_name,
+       pools: %{
+         default: [count: 1, size: 2, pool_max_idle_time: 100]
+       }}
+    )
+
+    Bypass.expect(bypass, fn conn ->
+      {"delay", str_delay} =
+        Enum.find(conn.req_headers, fn h -> match?({"delay", _}, h) end)
+
+      Process.sleep(String.to_integer(str_delay))
+      Plug.Conn.send_resp(conn, 200, "OK")
+    end)
+
+    delay_exec = fn ref, delay ->
+      send(parent, {ref, :start})
+
+      resp =
+        Finch.build(:get, endpoint(bypass), [{"delay", "#{delay}"}])
+        |> Finch.request(finch_name)
+
+      send(parent, {ref, :done})
+
+      resp
+    end
+
+    ref1 = make_ref()
+    ref2 = make_ref()
+
+    Task.async(fn -> delay_exec.(ref1, 10) end)
+    Task.async(fn -> delay_exec.(ref2, 10) end)
+
+    assert_receive {^ref1, :done}
+    assert_receive {^ref2, :done}
+
+    assert [{pool, _pool_mod}] = Registry.lookup(finch_name, shp(bypass))
+
+    Process.monitor(pool)
+
+    ref2 = make_ref()
+    Task.async(fn -> delay_exec.(ref2, 1000) end)
+
+    assert_receive {^ref2, :start}
+
+    refute_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 1000
+
+    assert_receive {^ref2, :done}
+
+    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 200
+
+    assert [] = DynamicSupervisor.which_children(:"#{finch_name}.PoolSupervisor")
+  end
+
   describe "async_request" do
     @describetag bypass: false
 


### PR DESCRIPTION
closes https://github.com/sneako/finch/issues/291

Currently, idle verification stops the pool if the first connection exceeds the idle timeout. I don’t believe this is the correct behavior, as it may lead to bugs like those described in the issue.

The general approach here was to add a last checkout timestamp to the pool state and verify it in the handle_ping callback.

While I’m not keen on adding this to the pool state just for idle verification, I couldn’t think of a better solution. 

I’ll look into the possibility of adding a handle_ping callback specifically for the pool in nimble_pool, as the current handle_ping applies only to workers and doesn’t fully align with our use case. I think this would provide the semantics we need in Finch.