### PR TITLE
Return acc when Finch.{stream,stream_while}/5 fails

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -146,6 +146,7 @@ defmodule Finch.HTTP1.Conn do
                 conn,
                 mint,
                 error,
+                acc,
                 metadata,
                 start_time,
                 extra_measurements
@@ -153,7 +154,7 @@ defmodule Finch.HTTP1.Conn do
           end
 
         {:error, mint, error} ->
-          handle_request_error(conn, mint, error, metadata, start_time, extra_measurements)
+          handle_request_error(conn, mint, error, acc, metadata, start_time, extra_measurements)
       end
     catch
       kind, error ->
@@ -166,10 +167,10 @@ defmodule Finch.HTTP1.Conn do
   defp stream_or_body({:stream, _}), do: :stream
   defp stream_or_body(body), do: body
 
-  defp handle_request_error(conn, mint, error, metadata, start_time, extra_measurements) do
+  defp handle_request_error(conn, mint, error, acc, metadata, start_time, extra_measurements) do
     metadata = Map.put(metadata, :error, error)
     Telemetry.stop(:send, start_time, metadata, extra_measurements)
-    {:error, %{conn | mint: mint}, error}
+    {:error, %{conn | mint: mint}, error, acc}
   end
 
   defp maybe_stream_request_body(mint, ref, {:stream, stream}) do
@@ -201,10 +202,10 @@ defmodule Finch.HTTP1.Conn do
         Telemetry.stop(:recv, start_time, metadata, extra_measurements)
         {:ok, %{conn | mint: mint}, acc}
 
-      {:error, mint, error, resp_metadata} ->
+      {:error, mint, error, acc, resp_metadata} ->
         metadata = Map.merge(metadata, Map.put(resp_metadata, :error, error))
         Telemetry.stop(:recv, start_time, metadata, extra_measurements)
-        {:error, %{conn | mint: mint}, error}
+        {:error, %{conn | mint: mint}, error, acc}
     end
   end
 
@@ -234,7 +235,7 @@ defmodule Finch.HTTP1.Conn do
 
   defp receive_response(
          _,
-         _acc,
+         acc,
          _fun,
          mint,
          _ref,
@@ -244,7 +245,7 @@ defmodule Finch.HTTP1.Conn do
        )
        when timeouts.request_timeout < 0 do
     {:ok, mint} = Mint.HTTP1.close(mint)
-    {:error, mint, %Mint.TransportError{reason: :timeout}, resp_metadata}
+    {:error, mint, %Mint.TransportError{reason: :timeout}, acc, resp_metadata}
   end
 
   defp receive_response(
@@ -281,7 +282,7 @@ defmodule Finch.HTTP1.Conn do
         )
 
       {:error, mint, error, _responses} ->
-        {:error, mint, error, resp_metadata}
+        {:error, mint, error, acc, resp_metadata}
     end
   end
 
@@ -365,7 +366,7 @@ defmodule Finch.HTTP1.Conn do
         end
 
       {:error, ^ref, error} ->
-        {:error, mint, error, resp_metadata}
+        {:error, mint, error, acc, resp_metadata}
     end
   end
 end

--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -11,7 +11,7 @@ defmodule Finch.Pool do
               Finch.stream(acc),
               Finch.name(),
               list()
-            ) :: {:ok, acc} | {:error, term()}
+            ) :: {:ok, acc} | {:error, term(), acc}
             when acc: term()
 
   @callback async_request(

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -75,7 +75,7 @@ defmodule Finch.HTTP2.PoolTest do
           start_pool(port)
         end)
 
-      assert {:error, error} = request(pool, %{req | headers: [{"foo", "bar"}]}, [])
+      assert {:error, error, _acc} = request(pool, %{req | headers: [{"foo", "bar"}]}, [])
       assert %{reason: {:max_header_list_size_exceeded, _, _}} = error
     end
 
@@ -105,7 +105,7 @@ defmodule Finch.HTTP2.PoolTest do
       :timer.sleep(10)
 
       # We can't send any more requests since the connection is closed for writing.
-      assert {:error, %Finch.Error{reason: :read_only}} = request(pool, req, [])
+      assert {:error, %Finch.Error{reason: :read_only}, _acc} = request(pool, req, [])
 
       server_send_frames([
         headers(stream_id: stream_id, hbf: hbf, flags: set_flags(:headers, [:end_headers])),
@@ -120,7 +120,7 @@ defmodule Finch.HTTP2.PoolTest do
       Process.sleep(50)
 
       # If we try to make a request now that the server shut down, we get an error.
-      assert {:error, %Finch.Error{reason: :disconnected}} = request(pool, req, [])
+      assert {:error, %Finch.Error{reason: :disconnected}, _acc} = request(pool, req, [])
     end
 
     test "if server disconnects while there are waiting clients, we notify those clients", %{
@@ -148,7 +148,7 @@ defmodule Finch.HTTP2.PoolTest do
 
       :ok = :ssl.close(server_socket())
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :connection_closed}}}
+      assert_receive {:resp, {:error, %Finch.Error{reason: :connection_closed}, _acc}}
     end
 
     test "if connections reaches max concurrent streams, we return an error", %{request: req} do
@@ -165,7 +165,7 @@ defmodule Finch.HTTP2.PoolTest do
 
       assert_recv_frames([headers(stream_id: _stream_id)])
 
-      assert {:error, %Mint.HTTPError{reason: :too_many_concurrent_requests}} =
+      assert {:error, %Mint.HTTPError{reason: :too_many_concurrent_requests}, _acc} =
                request(pool, req, [])
     end
 
@@ -184,7 +184,7 @@ defmodule Finch.HTTP2.PoolTest do
 
       assert_recv_frames([headers(stream_id: stream_id), rst_stream(stream_id: stream_id)])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}}}
+      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
     end
 
     test "request timeout with timeout > 0", %{request: req} do
@@ -208,7 +208,7 @@ defmodule Finch.HTTP2.PoolTest do
         headers(stream_id: stream_id, hbf: hbf, flags: set_flags(:headers, [:end_headers]))
       ])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}}}
+      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
     end
 
     test "request timeout with timeout > 0 that fires after request is done", %{request: req} do
@@ -267,7 +267,7 @@ defmodule Finch.HTTP2.PoolTest do
       # When there's a timeout, we cancel the request.
       assert_recv_frames([rst_stream(stream_id: ^stream_id, error_code: :cancel)])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}}}
+      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
     end
   end
 


### PR DESCRIPTION
Currently `Finch.stream/5` and `Finch.stream_while/5` do not return accumulator in case of errors. If an error happens midway through streaming, there may be information in the accumulator that the user would like to access when handling the error.

This originally came up in https://github.com/wojtekmach/req/pull/435#discussion_r1853832157, where in the `{:status, 200}` handler we "open" collectable with `Collectable.into(collectable)` and put it in the accumulator. If the request fails, we want to call `collector.(:halt)`, however `collector` is only available in `acc`, and not returned on errors.

This changes the signatures as follows:

```diff
@spec stream(Request.t(), name(), acc, stream(acc), request_opts()) ::
-        {:ok, acc} | {:error, Exception.t()}
+        {:ok, acc} | {:error, Exception.t(), acc}
```

```diff
@spec stream_while(Request.t(), name(), acc, stream_while(acc), request_opts()) ::
-        {:ok, acc} | {:error, Exception.t()}
+        {:ok, acc} | {:error, Exception.t(), acc}
```

This is a breaking change, but I think it's justified, since it removes a constraint, thus making it more flexible for the user.