### PR TITLE
Support manual pool termination

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -675,12 +675,17 @@ defmodule Finch do
   end
 
   def stop_pool(finch_name, shp) when is_tuple(shp) do
-    case PoolManager.get_pool(finch_name, shp, auto_start?: false) do
-      {pid, _pool_mod} ->
-        DynamicSupervisor.terminate_child(pool_supervisor_name(finch_name), pid)
-
-      :not_found ->
+    case PoolManager.all_pool_instances(finch_name, shp) do
+      [] ->
         {:error, :not_found}
+
+      children ->
+        Enum.each(
+          children,
+          fn {pid, _module} ->
+            DynamicSupervisor.terminate_child(pool_supervisor_name(finch_name), pid)
+          end
+        )
     end
   end
 end

--- a/lib/finch/pool_manager.ex
+++ b/lib/finch/pool_manager.ex
@@ -47,7 +47,7 @@ defmodule Finch.PoolManager do
   end
 
   def lookup_pool(registry, key) do
-    case Registry.lookup(registry, key) do
+    case all_pool_instances(registry, key) do
       [] ->
         :none
 
@@ -59,6 +59,8 @@ defmodule Finch.PoolManager do
         Enum.random(pools)
     end
   end
+
+  def all_pool_instances(registry, key), do: Registry.lookup(registry, key)
 
   def start_pools(registry_name, shp) do
     {:ok, config} = Registry.meta(registry_name, :config)

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -1026,7 +1026,9 @@ defmodule FinchTest do
     end
 
     test "succeeds with a string url", %{bypass: bypass, finch_name: finch_name} do
-      start_supervised!({Finch, name: finch_name, pools: %{default: [start_pool_metrics?: true]}})
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{default: [start_pool_metrics?: true, count: 2]}}
+      )
 
       Bypass.expect_once(bypass, "GET", "/", fn conn -> Plug.Conn.send_resp(conn, 200, "OK") end)
 
@@ -1039,7 +1041,9 @@ defmodule FinchTest do
     end
 
     test "succeeds with an shp tuple", %{bypass: bypass, finch_name: finch_name} do
-      start_supervised!({Finch, name: finch_name, pools: %{default: [start_pool_metrics?: true]}})
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{default: [start_pool_metrics?: true, count: 2]}}
+      )
 
       Bypass.expect_once(bypass, "GET", "/", fn conn -> Plug.Conn.send_resp(conn, 200, "OK") end)
 


### PR DESCRIPTION
This PR introduces `Finch.stop_pool/2`, which can be used to manually stop the connection pool of a given SHP.

We have tried it out in production, and it works fine, and it helped us fix our process leak.

See #294 for details.

It's worth noting that this function might not be enough. The client needs to make sure that no request to the given SHP is taking place while the pool is being stopped. This can actually be tricky. A simple solution of channeling all requests through a single process means that you can only have one req at a time to the given SHP, which might be a problem.

In our case we've implemented a basic reference counted GC mechanism, which tracks all the processes currently making a request to the given SHP. When there are no requests taking place anymore, the pool is stopped.

I could be open to submit a PR for something like that, but the proper implementation will be much more complicated, because it has to support the differences between HTTP 1 and 2 implementations, especially for async requests.