### PR TITLE
adds :supported_groups to list of tls options

### DIFF
--- a/lib/finch/pool_manager.ex
+++ b/lib/finch/pool_manager.ex
@@ -14,6 +14,7 @@ defmodule Finch.PoolManager do
     :server_name_indication,
     :signature_algs,
     :signature_algs_cert,
+    :supported_groups,
     :verify,
     :verify_fun,
     :versions


### PR DESCRIPTION
Here's a PR that fixes https://github.com/sneako/finch/issues/305 if we decide that's a desirable change.