### PR TITLE
Be more explicit about the `:default` pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ children = [
   {Finch,
    name: MyConfiguredFinch,
    pools: %{
-     :default => [size: 10],
+     :default => [size: 10, count: 2],
      "https://hex.pm" => [size: 32, count: 8]
    }}
 ]
@@ -59,7 +59,11 @@ children = [
 
 Pools will be started for each configured `{scheme, host, port}` when Finch is started.
 For any unconfigured `{scheme, host, port}`, the pool will be started the first time
-it is requested. Note pools are not automatically terminated by default, if you need to
+it is requested using the `:default` configuration. This means given the pool
+configuration above each origin/`{scheme, host, port}` will launch 2 (`:count`) new pool
+processes. So, if you encountered 10 separate combinations, that'd be 20 pool processes.
+
+Note pools are not automatically terminated by default, if you need to
 terminate them after some idle time, use the `pool_max_idle_time` option (available only for HTTP1 pools).
 
 ## Telemetry

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -151,7 +151,8 @@ defmodule Finch do
     * `:pools` - A map specifying the configuration for your pools. The keys should be URLs
     provided as binaries, a tuple `{scheme, {:local, unix_socket}}` where `unix_socket` is the path for
     the socket, or the atom `:default` to provide a catch-all configuration to be used for any
-    unspecified URLs. See "Pool Configuration Options" below for details on the possible map
+    unspecified URLs - meaning that new pools for unspecified URLs will be started using the `:default`
+    configuration. See "Pool Configuration Options" below for details on the possible map
     values. Default value is `%{default: [size: #{@default_pool_size}, count: #{@default_pool_count}]}`.
 
   ### Pool Configuration Options


### PR DESCRIPTION
Until ~2 weeks ago all my co-workers and I were under the assumption that for not specified URLs a `:default` pool would be used, not that a new pool/pool group would be started for unknown origins/shp.

Hence, I aim to make this more explicit here as multiple people failed to grasp this (including myself :sweat-smile:).

Happy about feedback! And thanks for all your work!