### PR TITLE
Conform timeout errors

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -408,7 +408,7 @@ defmodule Finch.HTTP2.Pool do
     with {:pop, {request, data}} when not is_nil(request) <- {:pop, pop_request(data, ref)},
          {:ok, conn} <- HTTP2.cancel_request(data.conn, ref) do
       data = put_in(data.conn, conn)
-      send(request.from_pid, {request.request_ref, {:error, Error.exception(:request_timeout)}})
+      send(request.from_pid, {request.request_ref, {:error, %Mint.TransportError{reason: :timeout}}})
       {:keep_state, data}
     else
       {:error, conn, _error} ->
@@ -522,7 +522,7 @@ defmodule Finch.HTTP2.Pool do
 
     # Its possible that the request doesn't exist so we guard against that here.
     if request != nil do
-      send(request.from_pid, {request.request_ref, {:error, Error.exception(:request_timeout)}})
+      send(request.from_pid, {request.request_ref, {:error, %Mint.TransportError{reason: :timeout}}})
     end
 
     # If we're out of requests then we should enter the disconnected state.

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -184,7 +184,7 @@ defmodule Finch.HTTP2.PoolTest do
 
       assert_recv_frames([headers(stream_id: stream_id), rst_stream(stream_id: stream_id)])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
+      assert_receive {:resp, {:error, %Mint.TransportError{reason: :timeout}, _acc}}
     end
 
     test "request timeout with timeout > 0", %{request: req} do
@@ -208,7 +208,7 @@ defmodule Finch.HTTP2.PoolTest do
         headers(stream_id: stream_id, hbf: hbf, flags: set_flags(:headers, [:end_headers]))
       ])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
+      assert_receive {:resp, {:error, %Mint.TransportError{reason: :timeout}, _acc}}
     end
 
     test "request timeout with timeout > 0 that fires after request is done", %{request: req} do
@@ -267,7 +267,7 @@ defmodule Finch.HTTP2.PoolTest do
       # When there's a timeout, we cancel the request.
       assert_recv_frames([rst_stream(stream_id: ^stream_id, error_code: :cancel)])
 
-      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
+      assert_receive {:resp, {:error, %Mint.TransportError{reason: :timeout}, _acc}}
     end
   end
 
@@ -294,7 +294,7 @@ defmodule Finch.HTTP2.PoolTest do
         Finch.build(:get, url <> "/wait/100")
         |> Finch.async_request(finch_name, receive_timeout: 10)
 
-      assert_receive {^request_ref, {:error, %{reason: :request_timeout}}}, 300
+      assert_receive {^request_ref, {:error, %{reason: :timeout}}}, 300
     end
 
     test "canceled with cancel_async_request/1", %{test: finch_name} do


### PR DESCRIPTION
This conforms the timeout errors in HTTP2 to be the same as HTTP1. I think the errors should in general be encapsulated into just `Finch.Error` though, and be normalized so we can handle it generic in other libraries. This is already a breaking change, and it'll be much more of a breaking change with switching everything over to a common error but I think it'll make it easier for other libraries to handle common errors.