### PR TITLE
Discard not ready connections from HTTP/2 pool

### DIFF
--- a/test/support/mock_http2_server.ex
+++ b/test/support/mock_http2_server.ex
@@ -3,7 +3,7 @@ defmodule Finch.MockHTTP2Server do
   import ExUnit.Assertions
   alias Mint.HTTP2.Frame
 
-  defstruct [:socket, :encode_table, :decode_table]
+  defstruct [:socket, :encode_table, :decode_table, :listen_socket, :server_settings]
 
   @fixtures_dir Path.expand("../fixtures", __DIR__)
 
@@ -35,7 +35,9 @@ defmodule Finch.MockHTTP2Server do
     server = %__MODULE__{
       socket: server_socket,
       encode_table: HPAX.new(4096),
-      decode_table: HPAX.new(4096)
+      decode_table: HPAX.new(4096),
+      listen_socket: listen_socket,
+      server_settings: server_settings
     }
 
     {result, server}
@@ -104,6 +106,10 @@ defmodule Finch.MockHTTP2Server do
   @spec get_socket(%__MODULE__{}) :: :ssl.sslsocket()
   def get_socket(server) do
     server.socket
+  end
+
+  def accept_socket(%__MODULE__{listen_socket: listen_socket, server_settings: server_settings}) do
+    accept(listen_socket, self(), server_settings)
   end
 
   defp accept(listen_socket, parent, server_settings) do


### PR DESCRIPTION
HTTP2 connections will unregister themselves from the pool once enter connected_read_only and disconnected states, and register themselves on init or after they reconnect.

Fixes #216, replaces #227.
