### PR TITLE
Encapsulate pool identifiers

### DIFF
--- a/lib/finch/http1/pool_metrics.ex
+++ b/lib/finch/http1/pool_metrics.ex
@@ -34,12 +34,12 @@ defmodule Finch.HTTP1.PoolMetrics do
     in_use_connections: 3
   ]
 
-  def init(registry, shp, pool_idx, pool_size) do
+  def init(registry, pool, pool_idx, pool_size) do
     ref = :atomics.new(length(@atomic_idx), [])
     :atomics.add(ref, @atomic_idx[:pool_idx], pool_idx)
     :atomics.add(ref, @atomic_idx[:pool_size], pool_size)
 
-    :persistent_term.put({__MODULE__, registry, shp, pool_idx}, ref)
+    :persistent_term.put({__MODULE__, registry, pool, pool_idx}, ref)
     {:ok, ref}
   end
 
@@ -51,8 +51,8 @@ defmodule Finch.HTTP1.PoolMetrics do
     end)
   end
 
-  def get_pool_status(name, shp, pool_idx) do
-    {__MODULE__, name, shp, pool_idx}
+  def get_pool_status(name, pool, pool_idx) do
+    {__MODULE__, name, pool, pool_idx}
     |> :persistent_term.get(nil)
     |> get_pool_status()
   end

--- a/lib/finch/http2/pool_metrics.ex
+++ b/lib/finch/http2/pool_metrics.ex
@@ -25,11 +25,11 @@ defmodule Finch.HTTP2.PoolMetrics do
     in_flight_requests: 2
   ]
 
-  def init(finch_name, shp, pool_idx) do
+  def init(finch_name, pool, pool_idx) do
     ref = :atomics.new(length(@atomic_idx), [])
     :atomics.put(ref, @atomic_idx[:pool_idx], pool_idx)
 
-    :persistent_term.put({__MODULE__, finch_name, shp, pool_idx}, ref)
+    :persistent_term.put({__MODULE__, finch_name, pool, pool_idx}, ref)
     {:ok, ref}
   end
 
@@ -41,8 +41,8 @@ defmodule Finch.HTTP2.PoolMetrics do
     end)
   end
 
-  def get_pool_status(name, shp, pool_idx) do
-    {__MODULE__, name, shp, pool_idx}
+  def get_pool_status(name, pool, pool_idx) do
+    {__MODULE__, name, pool, pool_idx}
     |> :persistent_term.get(nil)
     |> get_pool_status()
   end

--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -1,9 +1,11 @@
 defmodule Finch.Pool do
-  @moduledoc false
+  @moduledoc "Pool identifier management"
   # Defines a behaviour that both http1 and http2 pools need to implement.
 
+  @typedoc false
   @type request_ref :: {pool_mod :: module(), cancel_ref :: term()}
 
+  @doc false
   @callback request(
               pid(),
               Finch.Request.t(),
@@ -14,6 +16,7 @@ defmodule Finch.Pool do
             ) :: {:ok, acc} | {:error, term(), acc}
             when acc: term()
 
+  @doc false
   @callback async_request(
               pid(),
               Finch.Request.t(),
@@ -21,12 +24,40 @@ defmodule Finch.Pool do
               list()
             ) :: request_ref()
 
+  @doc false
   @callback cancel_async_request(request_ref()) :: :ok
 
-  @callback get_pool_status(
-              finch_name :: atom(),
-              {schema :: atom(), host :: String.t(), port :: integer()}
-            ) :: {:ok, list(map)} | {:error, :not_found}
+  @doc false
+  @callback get_pool_status(finch_name :: atom(), %__MODULE__{}) ::
+              {:ok, list(map)} | {:error, :not_found}
 
+  @enforce_keys [:scheme, :host, :port]
+  defstruct [:scheme, :host, :port]
+
+  @type t :: %__MODULE__{
+          scheme: :http | :https,
+          host: String.t() | {:local, String.t()},
+          port: :inet.port_number()
+        }
+
+  @doc false
+  def new(scheme, host, port) do
+    %__MODULE__{
+      scheme: scheme,
+      host: host,
+      port: port
+    }
+  end
+
+  @doc false
+  def from_url(url) when is_binary(url) do
+    {scheme, host, port, _path, _query} = Finch.Request.parse_url(url)
+    new(scheme, host, port)
+  end
+
+  @doc false
+  def to_shp(%__MODULE__{scheme: s, host: h, port: p}), do: {s, h, p}
+
+  @doc false
   defguard is_request_ref(ref) when tuple_size(ref) == 2 and is_atom(elem(ref, 0))
 end

--- a/test/finch/http1/pool_test.exs
+++ b/test/finch/http1/pool_test.exs
@@ -106,7 +106,8 @@ defmodule Finch.HTTP1.PoolTest do
 
     # after here the next idle termination will trigger in =~  ms
 
-    assert [{pool, _pool_mod}] = Registry.lookup(finch_name, shp(bypass))
+    pool_key = pool(bypass)
+    assert [{pool, _pool_mod}] = Registry.lookup(finch_name, pool_key)
 
     Process.monitor(pool)
 
@@ -169,7 +170,8 @@ defmodule Finch.HTTP1.PoolTest do
     assert_receive {^ref1, :done}
     assert_receive {^ref2, :done}
 
-    assert [{pool, _pool_mod}] = Registry.lookup(finch_name, shp(bypass))
+    pool_key = pool(bypass)
+    assert [{pool, _pool_mod}] = Registry.lookup(finch_name, pool_key)
 
     Process.monitor(pool)
 
@@ -268,6 +270,6 @@ defmodule Finch.HTTP1.PoolTest do
     end
   end
 
-  defp shp(%{port: port}), do: {:http, "localhost", port}
-  defp shp({scheme, {:local, unix_socket}}), do: {scheme, {:local, unix_socket}, 0}
+  defp pool(%{port: port}), do: Finch.Pool.new(:http, "localhost", port)
+  defp pool({scheme, {:local, unix_socket}}), do: Finch.Pool.new(scheme, {:local, unix_socket}, 0)
 end

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -30,8 +30,10 @@ defmodule Finch.HTTP2.PoolTest do
   end
 
   def start_pool(port) do
+    pool = Finch.Pool.new(:https, "localhost", port)
+
     Pool.start_link({
-      {:https, "localhost", port},
+      pool,
       :test,
       [conn_opts: [transport_opts: [verify: :verify_none]]],
       false,


### PR DESCRIPTION
I've started to do some work on https://github.com/sneako/finch/issues/296, and my idea is to allow for extra tags for a pool. The URL (and the `{schema, host, port}` that derives from it) is needed to identify a TCP connection, and therefore that we can't drop, so in order to distinguish two different TCP connections, my idea is to extend the identifier with "tags" (a tenant ID, a JWT, a customer name...). But before I can do that, the actual identifier I want to extend is scattered all over the repository and thought it'd be more incremental to separate encapsulating that from the rest of the work, as this is technically a refactor with no behavioural change, while the follow-up will have behaviour changes.

@sneako it's a bit noisy diff, but it's hopefully easy and a fine change. WDYT? I'm planning the follow up mentioned in the next few days :)