### PR TITLE
Removed the deprecated functionality

### DIFF
--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -214,9 +214,6 @@ defmodule Finch.HTTP1.Pool do
           port: pool.port
         }
 
-        # Deprecated, remember to delete when we remove the :max_idle_time pool config option!
-        Telemetry.event(:max_idle_time_exceeded, %{idle_time: idle_time}, meta)
-
         Telemetry.event(:conn_max_idle_time_exceeded, %{idle_time: idle_time}, meta)
 
         {:remove, :closed, pool_state}

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -241,22 +241,6 @@ defmodule Finch.Telemetry do
     * `:scheme` - The scheme used in the connection. either `http` or `https`.
     * `:host` - The host address.
     * `:port` - The port to connect on.
-
-  ### Max Idle Time Exceeded (Deprecated)
-
-  `[:finch, :max_idle_time_exceeded]` - Executed if an HTTP1 connection was discarded because the `max_idle_time` had been reached.
-
-  *Deprecated:* use `:conn_max_idle_time_exceeded` event instead.
-
-  #### Measurements
-
-    * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
-
-  #### Metadata
-
-    * `:scheme` - The scheme used in the connection. either `http` or `https`.
-    * `:host` - The host address.
-    * `:port` - The port to connect on.
   """
 
   @doc false

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -1,26 +1,12 @@
 defmodule FinchTest do
   use FinchCase, async: true
 
-  import ExUnit.CaptureIO
-
   alias Finch.Response
   alias Finch.MockSocketServer
 
   describe "start_link/1" do
     test "raises if :name is not provided" do
       assert_raise(ArgumentError, ~r/must supply a name/, fn -> Finch.start_link([]) end)
-    end
-
-    test "max_idle_time is deprecated", %{finch_name: finch_name} do
-      msg =
-        capture_io(:stderr, fn ->
-          start_supervised!({Finch, name: finch_name, pools: %{default: [max_idle_time: 1_000]}})
-        end)
-
-      assert String.contains?(
-               msg,
-               ":max_idle_time option is deprecated. Use :conn_max_idle_time instead."
-             )
     end
 
     test "multiple instances can be started under a single supervisor without additional configuration",


### PR DESCRIPTION
- Dropped :protocol and :max_idle_time from the pool config schema and simplified pool module selection to only use :protocols; also removed the deprecated Finch.request/6 overloads. lib/finch.ex
- Stopped emitting the deprecated :max_idle_time_exceeded telemetry event and removed its docs. lib/finch/http1/pool.ex, lib/finch/telemetry.ex
- Removed tests that only existed to validate deprecated behavior. test/finch_test.exs, test/finch/http1/telemetry_test.exs