### PR TITLE
Add runtime pool resize and replace persistent_term metrics with ETS

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,13 +15,13 @@ jobs:
         include:
           - pair:
               elixir: "1.15"
-              otp: "24"
+              otp: "26"
           - pair:
               elixir: "1.19"
-              otp: "28.3"
+              otp: "28.4"
           - pair:
-              elixir: "1.20.0-rc.1"
-              otp: "28.3.1"
+              elixir: "1.20.0-rc.3"
+              otp: "28.4"
               version-type: strict
             lint: lint
     steps:

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -1004,7 +1004,9 @@ defmodule Finch do
   def get_pool_status(finch_name, :default) do
     finch_name
     |> Pool.Manager.get_default_pools()
-    |> Enum.reduce(%{}, fn {_pid, {pool_name, pool_mod, pool_count}}, acc ->
+    |> Enum.reduce(%{}, fn {_sup_pid, {pool_name, pool_mod}}, acc ->
+      pool_count = Registry.count_match(finch_name, pool_name, :_)
+
       case pool_mod.get_pool_status(finch_name, pool_name, pool_count) do
         {:ok, metrics} ->
           pool_id = Pool.from_name(pool_name)
@@ -1113,8 +1115,8 @@ defmodule Finch do
 
   Returns `:ok` on success, `{:error, :not_found}` if the pool doesn't exist.
 
-  Only pools that were explicitly configured or dynamically started via
-  `Finch.start_pool/3` can be resized. Default (catch-all) pools cannot be resized.
+  Works with all kinds of pools, but note that `:default` pools must have
+  been materialized by at least one request before they can be resized.
 
   ## Examples
 

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -1022,7 +1022,7 @@ defmodule Finch do
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
-      {_pid, pool_name, pool_mod, pool_count} ->
+      {_pid, pool_name, pool_mod, pool_count, _pool_config} ->
         pool_mod.get_pool_status(finch_name, pool_name, pool_count)
 
       :not_found ->
@@ -1078,8 +1078,45 @@ defmodule Finch do
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
       :not_found -> {:error, :not_found}
-      {pid, _pool_name, _pool_mod, _pool_count} -> Supervisor.stop(pid)
+      {pid, _pool_name, _pool_mod, _pool_count, _pool_config} -> Supervisor.stop(pid)
     end
+  end
+
+  @doc """
+  Returns the current worker count for the given pool.
+
+  Returns `{:ok, count}` if the pool exists, `{:error, :not_found}` otherwise.
+
+  ## Examples
+
+      {:ok, count} = Finch.get_pool_count(MyFinch, "https://example.com")
+  """
+  @spec get_pool_count(name(), pool_identifier()) :: {:ok, pos_integer()} | {:error, :not_found}
+  def get_pool_count(finch_name, pool_identifier) do
+    pool = resolve_pool(pool_identifier)
+
+    case Pool.Manager.get_pool_supervisor(finch_name, pool) do
+      :not_found -> {:error, :not_found}
+      {_pid, _pool_name, _pool_mod, pool_count, _pool_config} -> {:ok, pool_count}
+    end
+  end
+
+  @doc """
+  Dynamically changes the number of pool workers for the given pool.
+
+  Returns `:ok` on success, `{:error, :not_found}` if the pool doesn't exist.
+
+  Only pools that were explicitly configured or dynamically started via
+  `Finch.start_pool/3` can be resized. Default (catch-all) pools cannot be resized.
+
+  ## Examples
+
+      :ok = Finch.set_pool_count(MyFinch, "https://example.com", 4)
+  """
+  @spec set_pool_count(name(), pool_identifier(), pos_integer()) :: :ok | {:error, term()}
+  def set_pool_count(finch_name, pool_identifier, count) when is_integer(count) and count > 0 do
+    pool = resolve_pool(pool_identifier)
+    Pool.Manager.set_pool_count(finch_name, pool, count)
   end
 
   defp resolve_pool(%Finch.Pool{} = pool), do: pool

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -1004,8 +1004,8 @@ defmodule Finch do
   def get_pool_status(finch_name, :default) do
     finch_name
     |> Pool.Manager.get_default_pools()
-    |> Enum.reduce(%{}, fn {_sup_pid, {pool_name, pool_mod}}, acc ->
-      pool_count = Registry.count_match(finch_name, pool_name, :_)
+    |> Enum.reduce(%{}, fn {sup_pid, {pool_name, pool_mod}}, acc ->
+      pool_count = Supervisor.count_children(sup_pid).workers
 
       case pool_mod.get_pool_status(finch_name, pool_name, pool_count) do
         {:ok, metrics} ->

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -421,6 +421,8 @@ defmodule Finch do
 
   @impl true
   def init(config) do
+    Finch.PoolMetrics.new(config.registry_name)
+
     children = [
       {Registry,
        keys: :duplicate,
@@ -1077,8 +1079,13 @@ defmodule Finch do
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
-      :not_found -> {:error, :not_found}
-      {pid, _pool_name, _pool_mod, _pool_count, _pool_config} -> Supervisor.stop(pid)
+      :not_found ->
+        {:error, :not_found}
+
+      {pid, pool_name, _pool_mod, _pool_count, _pool_config} ->
+        result = Supervisor.stop(pid)
+        Finch.PoolMetrics.delete_pool(finch_name, pool_name)
+        result
     end
   end
 

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -310,6 +310,16 @@ defmodule Finch.HTTP1.Pool do
 
   def handle_cancelled(:queued, _pool_state), do: :ok
 
+  @impl NimblePool
+  def terminate_pool(_reason, %{
+        state: %__MODULE__.State{metric_ref: {table, pool_name, pool_idx}}
+      }) do
+    Finch.PoolMetrics.delete(table, pool_name, pool_idx)
+    :ok
+  end
+
+  def terminate_pool(_reason, _pool_state), do: :ok
+
   defp transfer_if_open(conn, state, {pid, _} = from) do
     if Conn.open?(conn) do
       if state == :fresh do

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -190,7 +190,7 @@ defmodule Finch.HTTP1.Pool do
   @impl NimblePool
   def handle_checkout(:checkout, _, %{mint: nil} = conn, %__MODULE__.State{} = pool_state) do
     idle_time = System.monotonic_time() - conn.last_checkin
-    PoolMetrics.maybe_add(pool_state.metric_ref, in_use_connections: 1)
+    PoolMetrics.maybe_add(pool_state.metric_ref, :in_use_connections, 1)
     {:ok, {:fresh, conn, idle_time}, conn, pool_state}
   end
 
@@ -204,7 +204,7 @@ defmodule Finch.HTTP1.Pool do
 
     with true <- Conn.reusable?(conn, idle_time),
          {:ok, conn} <- Conn.set_mode(conn, :passive) do
-      PoolMetrics.maybe_add(metric_ref, in_use_connections: 1)
+      PoolMetrics.maybe_add(metric_ref, :in_use_connections, 1)
       {:ok, {:reuse, conn, idle_time}, conn, update_activity_info(:checkout, pool_state)}
     else
       false ->
@@ -226,7 +226,7 @@ defmodule Finch.HTTP1.Pool do
   @impl NimblePool
   def handle_checkin(checkin, _from, _old_conn, %__MODULE__.State{} = pool_state) do
     %__MODULE__.State{metric_ref: metric_ref} = pool_state
-    PoolMetrics.maybe_add(metric_ref, in_use_connections: -1)
+    PoolMetrics.maybe_add(metric_ref, :in_use_connections, -1)
 
     with {:ok, conn} <- checkin,
          {:ok, conn} <- Conn.set_mode(conn, :active) do
@@ -304,7 +304,7 @@ defmodule Finch.HTTP1.Pool do
   @impl NimblePool
   def handle_cancelled(:checked_out, %__MODULE__.State{} = pool_state) do
     %__MODULE__.State{metric_ref: metric_ref} = pool_state
-    PoolMetrics.maybe_add(metric_ref, in_use_connections: -1)
+    PoolMetrics.maybe_add(metric_ref, :in_use_connections, -1)
     :ok
   end
 

--- a/lib/finch/http1/pool_metrics.ex
+++ b/lib/finch/http1/pool_metrics.ex
@@ -28,54 +28,38 @@ defmodule Finch.HTTP1.PoolMetrics do
     :in_use_connections
   ]
 
-  @atomic_idx [
-    pool_idx: 1,
-    pool_size: 2,
-    in_use_connections: 3
-  ]
+  alias Finch.PoolMetrics
 
-  def init(registry, pool_name, pool_idx, pool_size) do
-    ref = :atomics.new(length(@atomic_idx), [])
-    :atomics.add(ref, @atomic_idx[:pool_idx], pool_idx)
-    :atomics.add(ref, @atomic_idx[:pool_size], pool_size)
+  # Row layout: {{pool_name, pool_idx}, pool_size, in_use_connections}
+  @pos_in_use 3
 
-    :persistent_term.put({__MODULE__, registry, pool_name, pool_idx}, ref)
-    {:ok, ref}
+  def init(finch_name, pool_name, pool_idx, pool_size) do
+    table = PoolMetrics.table_name(finch_name)
+    PoolMetrics.insert(table, pool_name, pool_idx, [pool_size, 0])
+    {:ok, {table, pool_name, pool_idx}}
   end
 
-  def maybe_add(nil, _metrics_list), do: :ok
+  def maybe_add(nil, _, _), do: :ok
 
-  def maybe_add(ref, metrics_list) do
-    Enum.each(metrics_list, fn {metric_name, val} ->
-      :atomics.add(ref, @atomic_idx[metric_name], val)
-    end)
+  def maybe_add({table, pool_name, pool_idx}, :in_use_connections, delta) do
+    PoolMetrics.update(table, pool_name, pool_idx, @pos_in_use, delta)
   end
 
-  def get_pool_status(name, pool_name, pool_idx) do
-    {__MODULE__, name, pool_name, pool_idx}
-    |> :persistent_term.get(nil)
-    |> get_pool_status()
-  end
+  def get_pool_status(finch_name, pool_name, pool_idx) do
+    table = PoolMetrics.table_name(finch_name)
 
-  def get_pool_status(nil), do: {:error, :not_found}
+    case PoolMetrics.get_row(table, pool_name, pool_idx) do
+      nil ->
+        {:error, :not_found}
 
-  def get_pool_status(ref) do
-    %{
-      pool_idx: pool_idx,
-      pool_size: pool_size,
-      in_use_connections: in_use_connections
-    } =
-      @atomic_idx
-      |> Enum.map(fn {k, idx} -> {k, :atomics.get(ref, idx)} end)
-      |> Map.new()
-
-    result = %__MODULE__{
-      pool_index: pool_idx,
-      pool_size: pool_size,
-      available_connections: pool_size - in_use_connections,
-      in_use_connections: in_use_connections
-    }
-
-    {:ok, result}
+      {_key, pool_size, in_use} ->
+        {:ok,
+         %__MODULE__{
+           pool_index: pool_idx,
+           pool_size: pool_size,
+           available_connections: pool_size - in_use,
+           in_use_connections: in_use
+         }}
+    end
   end
 end

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -20,7 +20,7 @@ defmodule Finch.HTTP2.Pool do
   @backoff_max 10_000
   @backoff_max_failure_count ceil(:math.log2(@backoff_max / @backoff_base))
 
-  @impl true
+  @impl :gen_statem
   def callback_mode(), do: [:state_functions, :state_enter]
 
   def child_spec(opts) do
@@ -206,8 +206,10 @@ defmodule Finch.HTTP2.Pool do
     :gen_statem.start_link(__MODULE__, opts, [])
   end
 
-  @impl true
+  @impl :gen_statem
   def init({pool, pool_name, registry, pool_config, pool_idx}) do
+    Process.flag(:trap_exit, true)
+
     {:ok, metrics_ref} =
       if pool_config.start_pool_metrics?,
         do: PoolMetrics.init(registry, pool_name, pool_idx),
@@ -968,6 +970,13 @@ defmodule Finch.HTTP2.Pool do
   defp reply(%{from: from}, reply) do
     :gen_statem.reply(from, reply)
   end
+
+  @impl :gen_statem
+  def terminate(_reason, _state, %{metrics_ref: {table, pool_name, pool_idx}}) do
+    Finch.PoolMetrics.delete(table, pool_name, pool_idx)
+  end
+
+  def terminate(_reason, _state, _data), do: :ok
 
   defp update_max_concurrent_streams(%{metrics_ref: nil}), do: :ok
 

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -414,6 +414,7 @@ defmodule Finch.HTTP2.Pool do
 
   def connected(:enter, _old_state, data) do
     {:ok, _} = Registry.register(data.finch_name, data.pool_name, __MODULE__)
+    update_max_concurrent_streams(data)
     {:keep_state_and_data, ping_action(data)}
   end
 
@@ -444,6 +445,7 @@ defmodule Finch.HTTP2.Pool do
     case HTTP2.stream(data.conn, message) do
       {:ok, conn, responses} ->
         data = put_in(data.conn, conn)
+        update_max_concurrent_streams(data)
         {data, response_actions} = handle_responses(data, responses)
 
         cond do
@@ -910,7 +912,7 @@ defmodule Finch.HTTP2.Pool do
   end
 
   defp put_request(data, ref, request) do
-    PoolMetrics.maybe_add(data.metrics_ref, in_flight_requests: 1)
+    PoolMetrics.maybe_add(data.metrics_ref, :in_flight_requests, 1)
 
     data
     |> put_in([:requests, ref], request)
@@ -919,7 +921,7 @@ defmodule Finch.HTTP2.Pool do
   end
 
   defp pop_request(data, ref) do
-    PoolMetrics.maybe_add(data.metrics_ref, in_flight_requests: -1)
+    PoolMetrics.maybe_add(data.metrics_ref, :in_flight_requests, -1)
 
     case pop_in(data.requests[ref]) do
       {nil, data} ->
@@ -965,5 +967,12 @@ defmodule Finch.HTTP2.Pool do
 
   defp reply(%{from: from}, reply) do
     :gen_statem.reply(from, reply)
+  end
+
+  defp update_max_concurrent_streams(%{metrics_ref: nil}), do: :ok
+
+  defp update_max_concurrent_streams(%{conn: conn, metrics_ref: metrics_ref}) do
+    value = HTTP2.get_server_setting(conn, :max_concurrent_streams)
+    PoolMetrics.maybe_put(metrics_ref, :max_concurrent_streams, value)
   end
 end

--- a/lib/finch/http2/pool_metrics.ex
+++ b/lib/finch/http2/pool_metrics.ex
@@ -6,6 +6,9 @@ defmodule Finch.HTTP2.PoolMetrics do
 
     * `:pool_index` - Index of the pool
     * `:in_flight_requests` - Number of requests currently on the connection
+    * `:available_connections` - Number of available connections
+    * `:max_concurrent_streams` - The server's max concurrent streams setting.
+      This is 0 until the server's SETTINGS frame has been received.
 
   Caveats:
 
@@ -17,55 +20,54 @@ defmodule Finch.HTTP2.PoolMetrics do
 
   defstruct [
     :pool_index,
-    :in_flight_requests
+    :in_flight_requests,
+    :available_connections,
+    :max_concurrent_streams
   ]
 
-  @atomic_idx [
-    pool_idx: 1,
-    in_flight_requests: 2
-  ]
+  alias Finch.PoolMetrics
+
+  # Row layout: {{pool_name, pool_idx}, in_flight_requests, max_concurrent_streams}
+  @pos_in_flight 2
+  @pos_max_streams 3
 
   @doc false
   def init(finch_name, pool_name, pool_idx) do
-    ref = :atomics.new(length(@atomic_idx), [])
-    :atomics.put(ref, @atomic_idx[:pool_idx], pool_idx)
-
-    :persistent_term.put({__MODULE__, finch_name, pool_name, pool_idx}, ref)
-    {:ok, ref}
+    table = PoolMetrics.table_name(finch_name)
+    PoolMetrics.insert(table, pool_name, pool_idx, [0, 0])
+    {:ok, {table, pool_name, pool_idx}}
   end
 
   @doc false
-  def maybe_add(nil, _metrics_list), do: :ok
+  def maybe_add(nil, _, _), do: :ok
 
-  def maybe_add(ref, metrics_list) do
-    Enum.each(metrics_list, fn {metric_name, val} ->
-      :atomics.add(ref, @atomic_idx[metric_name], val)
-    end)
+  def maybe_add({table, pool_name, pool_idx}, :in_flight_requests, delta) do
+    PoolMetrics.update(table, pool_name, pool_idx, @pos_in_flight, delta)
   end
 
   @doc false
-  def get_pool_status(name, pool_name, pool_idx) do
-    {__MODULE__, name, pool_name, pool_idx}
-    |> :persistent_term.get(nil)
-    |> get_pool_status()
+  def maybe_put(nil, _metric, _value), do: :ok
+
+  def maybe_put({table, pool_name, pool_idx}, :max_concurrent_streams, value) do
+    PoolMetrics.put(table, pool_name, pool_idx, @pos_max_streams, value)
   end
 
-  def get_pool_status(nil), do: {:error, :not_found}
+  @doc false
+  def get_pool_status(finch_name, pool_name, pool_idx) do
+    table = PoolMetrics.table_name(finch_name)
 
-  def get_pool_status(ref) do
-    %{
-      pool_idx: pool_idx,
-      in_flight_requests: in_flight_requests
-    } =
-      @atomic_idx
-      |> Enum.map(fn {k, idx} -> {k, :atomics.get(ref, idx)} end)
-      |> Map.new()
+    case PoolMetrics.get_row(table, pool_name, pool_idx) do
+      nil ->
+        {:error, :not_found}
 
-    result = %__MODULE__{
-      pool_index: pool_idx,
-      in_flight_requests: in_flight_requests
-    }
-
-    {:ok, result}
+      {_key, in_flight, max_streams} ->
+        {:ok,
+         %__MODULE__{
+           pool_index: pool_idx,
+           in_flight_requests: in_flight,
+           available_connections: max_streams - in_flight,
+           max_concurrent_streams: max_streams
+         }}
+    end
   end
 end

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -148,14 +148,8 @@ defmodule Finch.Pool.Manager do
           :not_found
 
         [{pid, {pool_mod, _pool_count, pool_config}}] ->
-          # Derive current worker count from supervisor children for accurate
-          # count after runtime resize via set_pool_count/3
-          try do
-            pool_count = Supervisor.count_children(pid).workers
-            {pid, pool_name, pool_mod, pool_count, pool_config}
-          catch
-            :exit, _ -> :not_found
-          end
+          pool_count = Registry.count_match(finch_name, pool_name, :_)
+          {pid, pool_name, pool_mod, pool_count, pool_config}
       end
     else
       :not_found

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -148,7 +148,7 @@ defmodule Finch.Pool.Manager do
           :not_found
 
         [{pid, {pool_mod, _pool_count, pool_config}}] ->
-          pool_count = Registry.count_match(finch_name, pool_name, :_)
+          pool_count = Supervisor.count_children(pid).workers
           {pid, pool_name, pool_mod, pool_count, pool_config}
       end
     else

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -136,7 +136,7 @@ defmodule Finch.Pool.Manager do
   end
 
   @spec get_pool_supervisor(Finch.name(), Finch.Pool.t()) ::
-          {pid(), pool_name(), module(), pos_integer()} | :not_found
+          {pid(), pool_name(), module(), pos_integer(), map()} | :not_found
   def get_pool_supervisor(finch_name, %Finch.Pool{} = pool) do
     pool_name = Finch.Pool.to_name(pool)
 
@@ -144,8 +144,18 @@ defmodule Finch.Pool.Manager do
     # This prevents atom creation when checking non-existent instances.
     if Process.whereis(finch_name) do
       case Registry.lookup(supervisor_registry_name(finch_name), pool_name) do
-        [] -> :not_found
-        [{pid, {pool_mod, pool_count}}] -> {pid, pool_name, pool_mod, pool_count}
+        [] ->
+          :not_found
+
+        [{pid, {pool_mod, _pool_count, pool_config}}] ->
+          # Derive current worker count from supervisor children for accurate
+          # count after runtime resize via set_pool_count/3
+          try do
+            pool_count = Supervisor.count_children(pid).workers
+            {pid, pool_name, pool_mod, pool_count, pool_config}
+          catch
+            :exit, _ -> :not_found
+          end
       end
     else
       :not_found
@@ -163,7 +173,7 @@ defmodule Finch.Pool.Manager do
     {:ok, config} = Registry.meta(finch_name, :config)
     pool_name = Finch.Pool.to_name(pool)
     pool_config = sanitize_pool_config(opts, pool)
-    data = {pool_config.mod, pool_config.count}
+    data = {pool_config.mod, pool_config.count, pool_config}
     name = {:via, Registry, {config.supervisor_registry_name, pool_name, data}}
 
     Supervisor.child_spec(
@@ -172,13 +182,24 @@ defmodule Finch.Pool.Manager do
     )
   end
 
+  @spec set_pool_count(Finch.name(), Finch.Pool.t(), pos_integer()) :: :ok | {:error, term()}
+  def set_pool_count(finch_name, %Finch.Pool{} = pool, count) do
+    case get_pool_supervisor(finch_name, pool) do
+      :not_found ->
+        {:error, :not_found}
+
+      {pid, _pool_name, _pool_mod, old_count, pool_config} ->
+        Finch.Pool.Supervisor.set_count(pid, pool, finch_name, pool_config, old_count, count)
+    end
+  end
+
   ## Callbacks
 
   defp start_pool(pool, pool_name, config) do
     pool_config = pool_config(config, pool)
     track_default? = pool_config.start_pool_metrics? and not Map.has_key?(config.pools, pool)
 
-    data = {pool_config.mod, pool_config.count}
+    data = {pool_config.mod, pool_config.count, pool_config}
     name = {:via, Registry, {config.supervisor_registry_name, pool_name, data}}
 
     config.supervisor_name

--- a/lib/finch/pool/supervisor.ex
+++ b/lib/finch/pool/supervisor.ex
@@ -33,7 +33,6 @@ defmodule Finch.Pool.Supervisor do
         :ok
 
       new_count < old_count ->
-
         for pool_idx <- old_count..(new_count + 1)//-1 do
           Supervisor.terminate_child(sup_pid, pool_idx)
           Supervisor.delete_child(sup_pid, pool_idx)

--- a/lib/finch/pool/supervisor.ex
+++ b/lib/finch/pool/supervisor.ex
@@ -5,6 +5,8 @@ defmodule Finch.Pool.Supervisor do
   alias Finch.Pool
   use Supervisor, restart: :transient
 
+  @type pool_idx() :: pos_integer()
+
   def start_link({name, arg}) do
     Supervisor.start_link(__MODULE__, arg, name: name)
   end
@@ -22,29 +24,37 @@ defmodule Finch.Pool.Supervisor do
     Supervisor.init(specs, auto_shutdown: :all_significant, strategy: :one_for_one)
   end
 
+  @spec set_count(pid(), Pool.t(), Finch.name(), map(), pos_integer(), pos_integer()) ::
+          :ok | {:error, {pool_idx(), term()}}
   def set_count(sup_pid, pool, registry_name, pool_config, old_count, new_count) do
     cond do
       new_count > old_count ->
-        for pool_idx <- (old_count + 1)..new_count do
+        Enum.reduce_while((old_count + 1)..new_count, :ok, fn pool_idx, :ok ->
           spec = build_child_spec(pool, registry_name, pool_config, pool_idx)
-          Supervisor.start_child(sup_pid, spec)
-        end
 
-        :ok
+          case Supervisor.start_child(sup_pid, spec) do
+            {:ok, _pid} -> {:cont, :ok}
+            {:error, {:already_started, _pid}} -> {:cont, :ok}
+            {:error, reason} -> {:halt, {:error, {pool_idx, reason}}}
+          end
+        end)
 
       new_count < old_count ->
-        for pool_idx <- old_count..(new_count + 1)//-1 do
-          Supervisor.terminate_child(sup_pid, pool_idx)
-          Supervisor.delete_child(sup_pid, pool_idx)
-        end
-
-        :ok
+        Enum.reduce_while(old_count..(new_count + 1)//-1, :ok, fn pool_idx, :ok ->
+          with :ok <- Supervisor.terminate_child(sup_pid, pool_idx),
+               :ok <- Supervisor.delete_child(sup_pid, pool_idx) do
+            {:cont, :ok}
+          else
+            {:error, reason} -> {:halt, {:error, {pool_idx, reason}}}
+          end
+        end)
 
       true ->
         :ok
     end
   end
 
+  @spec build_child_spec(Pool.t(), Finch.name(), map(), pool_idx()) :: Supervisor.child_spec()
   defp build_child_spec(pool, registry_name, pool_config, pool_idx) do
     pool_name = Pool.to_name(pool)
     pool_args = {pool, pool_name, registry_name, pool_config, pool_idx}

--- a/lib/finch/pool/supervisor.ex
+++ b/lib/finch/pool/supervisor.ex
@@ -2,6 +2,7 @@ defmodule Finch.Pool.Supervisor do
   @moduledoc false
 
   # Supervisor each process in a pool (effectively one child per pool_config.count)
+  alias Finch.Pool
   use Supervisor, restart: :transient
 
   def start_link({name, arg}) do
@@ -9,7 +10,7 @@ defmodule Finch.Pool.Supervisor do
   end
 
   def init({registry_name, pool, pool_config, track_default?}) do
-    pool_name = Finch.Pool.to_name(pool)
+    pool_name = Pool.to_name(pool)
 
     if track_default? do
       Registry.register(registry_name, :default, {pool_name, pool_config.mod, pool_config.count})
@@ -32,6 +33,7 @@ defmodule Finch.Pool.Supervisor do
         :ok
 
       new_count < old_count ->
+
         for pool_idx <- old_count..(new_count + 1)//-1 do
           Supervisor.terminate_child(sup_pid, pool_idx)
           Supervisor.delete_child(sup_pid, pool_idx)
@@ -45,7 +47,7 @@ defmodule Finch.Pool.Supervisor do
   end
 
   defp build_child_spec(pool, registry_name, pool_config, pool_idx) do
-    pool_name = Finch.Pool.to_name(pool)
+    pool_name = Pool.to_name(pool)
     pool_args = {pool, pool_name, registry_name, pool_config, pool_idx}
 
     # If the children are transient or temporary, then we want to propagate shutdown up

--- a/lib/finch/pool/supervisor.ex
+++ b/lib/finch/pool/supervisor.ex
@@ -13,7 +13,7 @@ defmodule Finch.Pool.Supervisor do
     pool_name = Pool.to_name(pool)
 
     if track_default? do
-      Registry.register(registry_name, :default, {pool_name, pool_config.mod, pool_config.count})
+      Registry.register(registry_name, :default, {pool_name, pool_config.mod})
     end
 
     specs =

--- a/lib/finch/pool/supervisor.ex
+++ b/lib/finch/pool/supervisor.ex
@@ -16,19 +16,45 @@ defmodule Finch.Pool.Supervisor do
     end
 
     specs =
-      Enum.map(1..pool_config.count, fn pool_idx ->
-        pool_args = {pool, pool_name, registry_name, pool_config, pool_idx}
-
-        # If the children are transient or temporary, then we want to propagate shutdown up
-        case Supervisor.child_spec({pool_config.mod, pool_args}, id: pool_idx) do
-          %{restart: restart} = spec when restart in [:transient, :temporary] ->
-            Map.put(spec, :significant, true)
-
-          spec ->
-            spec
-        end
-      end)
+      Enum.map(1..pool_config.count, &build_child_spec(pool, registry_name, pool_config, &1))
 
     Supervisor.init(specs, auto_shutdown: :all_significant, strategy: :one_for_one)
+  end
+
+  def set_count(sup_pid, pool, registry_name, pool_config, old_count, new_count) do
+    cond do
+      new_count > old_count ->
+        for pool_idx <- (old_count + 1)..new_count do
+          spec = build_child_spec(pool, registry_name, pool_config, pool_idx)
+          Supervisor.start_child(sup_pid, spec)
+        end
+
+        :ok
+
+      new_count < old_count ->
+        for pool_idx <- old_count..(new_count + 1)//-1 do
+          Supervisor.terminate_child(sup_pid, pool_idx)
+          Supervisor.delete_child(sup_pid, pool_idx)
+        end
+
+        :ok
+
+      true ->
+        :ok
+    end
+  end
+
+  defp build_child_spec(pool, registry_name, pool_config, pool_idx) do
+    pool_name = Finch.Pool.to_name(pool)
+    pool_args = {pool, pool_name, registry_name, pool_config, pool_idx}
+
+    # If the children are transient or temporary, then we want to propagate shutdown up
+    case Supervisor.child_spec({pool_config.mod, pool_args}, id: pool_idx) do
+      %{restart: restart} = spec when restart in [:transient, :temporary] ->
+        Map.put(spec, :significant, true)
+
+      spec ->
+        spec
+    end
   end
 end

--- a/lib/finch/pool_metrics.ex
+++ b/lib/finch/pool_metrics.ex
@@ -71,10 +71,10 @@ defmodule Finch.PoolMetrics do
 
   @doc """
   Deletes the metrics row for a given pool worker.
+  Accepts the ETS table name directly.
   """
   @spec delete(atom(), term(), pos_integer()) :: true
-  def delete(registry_name, pool_name, pool_idx) do
-    table = table_name(registry_name)
+  def delete(table, pool_name, pool_idx) do
     :ets.delete(table, {pool_name, pool_idx})
   end
 

--- a/lib/finch/pool_metrics.ex
+++ b/lib/finch/pool_metrics.ex
@@ -1,0 +1,89 @@
+defmodule Finch.PoolMetrics do
+  @moduledoc false
+
+  # Unified pool metrics backed by a single ETS table per Finch instance.
+  #
+  # Each worker stores one row: {{pool_name, pool_idx}, metric1, metric2, ...}
+  # The key is {pool_name, pool_idx}; metric values occupy positions 2, 3, ...
+  # Protocol-specific modules (HTTP1/HTTP2 PoolMetrics) define which position
+  # holds which metric.
+  #
+  # The ETS table is created with `read_concurrency: true, write_concurrency: :auto`
+  # for scalable concurrent access from pool workers.
+
+  @doc """
+  Returns the ETS table name for a Finch instance.
+  """
+  @spec table_name(atom()) :: atom()
+  def table_name(finch_name), do: :"#{finch_name}.PoolMetrics"
+
+  @doc """
+  Creates the ETS table for a Finch instance. Called once during Finch.init/1.
+  """
+  @spec new(atom()) :: :ets.table()
+  def new(finch_name) do
+    :ets.new(table_name(finch_name), [
+      :set,
+      :public,
+      :named_table,
+      read_concurrency: true,
+      write_concurrency: :auto
+    ])
+  end
+
+  @doc """
+  Inserts a full metrics row for a pool worker.
+  `row` is a tuple like `{{pool_name, pool_idx}, val1, val2, ...}`.
+  """
+  @spec insert(atom(), term(), pos_integer(), list()) :: true
+  def insert(table, pool_name, pool_idx, row) when is_list(row) do
+    entry = [{pool_name, pool_idx}] ++ row
+    :ets.insert(table, List.to_tuple(entry))
+  end
+
+  @doc """
+  Atomically increments the value at `position` by `delta`.
+  Position 2 is the first metric value (position 1 is the key).
+  """
+  @spec update(atom(), term(), pos_integer(), pos_integer(), integer()) :: integer()
+  def update(table, pool_name, pool_idx, position, delta) do
+    :ets.update_counter(table, {pool_name, pool_idx}, {position, delta})
+  end
+
+  @doc """
+  Sets the value at `position` to an absolute value.
+  """
+  @spec put(atom(), term(), pos_integer(), pos_integer(), integer()) :: true
+  def put(table, pool_name, pool_idx, position, value) do
+    :ets.update_element(table, {pool_name, pool_idx}, {position, value})
+  end
+
+  @doc """
+  Reads the full metrics row for the given key. Returns `nil` if not found.
+  """
+  @spec get_row(atom(), term(), pos_integer()) :: tuple() | nil
+  def get_row(table, pool_name, pool_idx) do
+    case :ets.lookup(table, {pool_name, pool_idx}) do
+      [row] -> row
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Deletes the metrics row for a given pool worker.
+  """
+  @spec delete(atom(), term(), pos_integer()) :: true
+  def delete(registry_name, pool_name, pool_idx) do
+    table = table_name(registry_name)
+    :ets.delete(table, {pool_name, pool_idx})
+  end
+
+  @doc """
+  Deletes all metrics rows for all workers of a given pool.
+  """
+  @spec delete_pool(atom(), term()) :: true
+  def delete_pool(finch_name, pool_name) do
+    table = table_name(finch_name)
+    :ets.match_delete(table, {{pool_name, :_}, :_, :_})
+  end
+end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2341,6 +2341,50 @@ defmodule FinchTest do
       pool_name = Finch.Pool.to_name(pool(bypass))
       assert :ets.match(table, {{pool_name, :_}, :_, :_}) == []
     end
+
+    test "resizing a materialized default pool updates :default pool metrics", %{
+      bypass: bypass,
+      finch_name: finch_name
+    } do
+      start_supervised!({Finch, name: finch_name, pools: %{default: [start_pool_metrics?: true]}})
+
+      expect_any(bypass)
+
+      url = endpoint(bypass)
+      pool = pool(bypass)
+
+      # Materialize the catch-all default pool first.
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, url) |> Finch.request(finch_name)
+
+      assert {:ok, %{^pool => metrics}} = Finch.get_pool_status(finch_name, :default)
+      assert length(metrics) == 1
+
+      assert :ok = Finch.set_pool_count(finch_name, url, 3)
+      assert {:ok, 3} = Finch.get_pool_count(finch_name, url)
+
+      assert eventually(
+               fn ->
+                 case Finch.get_pool_status(finch_name, url) do
+                   {:ok, metrics} -> length(metrics) == 3
+                   _ -> false
+                 end
+               end,
+               100,
+               50
+             )
+
+      assert eventually(
+               fn ->
+                 case Finch.get_pool_status(finch_name, :default) do
+                   {:ok, %{^pool => metrics}} -> length(metrics) == 3
+                   _ -> false
+                 end
+               end,
+               100,
+               50
+             )
+    end
   end
 
   defp get_pools(name, pool) do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2288,6 +2288,59 @@ defmodule FinchTest do
       assert {:ok, %Response{status: 200}} =
                Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
     end
+
+    test "scale down cleans up metrics entries", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch,
+         name: finch_name,
+         pools: %{endpoint(bypass) => [count: 3, size: 5, start_pool_metrics?: true]}}
+      )
+
+      expect_any(bypass)
+
+      # Make a request so pools register
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
+
+      assert {:ok, metrics} = Finch.get_pool_status(finch_name, endpoint(bypass))
+      assert length(metrics) == 3
+
+      # Scale down to 1
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 1)
+
+      # Only 1 metric entry should remain
+      assert {:ok, [_single]} = Finch.get_pool_status(finch_name, endpoint(bypass))
+
+      # Verify orphaned entries are gone from ETS
+      table = Finch.PoolMetrics.table_name(finch_name)
+      pool_name = Finch.Pool.to_name(pool(bypass))
+      assert :ets.lookup(table, {pool_name, 2}) == []
+      assert :ets.lookup(table, {pool_name, 3}) == []
+    end
+
+    test "stop_pool cleans up all metrics entries", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch,
+         name: finch_name,
+         pools: %{endpoint(bypass) => [count: 2, size: 5, start_pool_metrics?: true]}}
+      )
+
+      expect_any(bypass)
+
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
+
+      assert {:ok, metrics} = Finch.get_pool_status(finch_name, endpoint(bypass))
+      assert length(metrics) == 2
+
+      # Stop the pool
+      assert :ok = Finch.stop_pool(finch_name, endpoint(bypass))
+
+      # All metrics should be cleaned up
+      table = Finch.PoolMetrics.table_name(finch_name)
+      pool_name = Finch.Pool.to_name(pool(bypass))
+      assert :ets.match(table, {{pool_name, :_}, :_, :_}) == []
+    end
   end
 
   defp get_pools(name, pool) do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2200,6 +2200,96 @@ defmodule FinchTest do
     end
   end
 
+  describe "get_pool_count/2 and set_pool_count/3" do
+    test "get_pool_count returns current count", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{endpoint(bypass) => [count: 2, size: 5]}}
+      )
+
+      assert {:ok, 2} = Finch.get_pool_count(finch_name, endpoint(bypass))
+    end
+
+    test "get_pool_count returns not_found for unknown pool", %{finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+      assert {:error, :not_found} = Finch.get_pool_count(finch_name, "http://unknown:9999")
+    end
+
+    test "scale up workers", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{endpoint(bypass) => [count: 1, size: 5]}}
+      )
+
+      expect_any(bypass)
+      assert {:ok, 1} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 3)
+      assert {:ok, 3} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      # Requests still work after scale up
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
+    end
+
+    test "scale down workers", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{endpoint(bypass) => [count: 3, size: 5]}}
+      )
+
+      expect_any(bypass)
+      assert {:ok, 3} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 1)
+      assert {:ok, 1} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      # Requests still work after scale down
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
+    end
+
+    test "same count is a no-op", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch, name: finch_name, pools: %{endpoint(bypass) => [count: 2, size: 5]}}
+      )
+
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 2)
+      assert {:ok, 2} = Finch.get_pool_count(finch_name, endpoint(bypass))
+    end
+
+    test "set_pool_count returns not_found for unknown pool", %{finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+      assert {:error, :not_found} = Finch.set_pool_count(finch_name, "http://unknown:9999", 2)
+    end
+
+    test "scale up and down with pool status", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!(
+        {Finch,
+         name: finch_name,
+         pools: %{endpoint(bypass) => [count: 1, size: 5, start_pool_metrics?: true]}}
+      )
+
+      expect_any(bypass)
+
+      # Scale up
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 3)
+      assert {:ok, 3} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      # Pool status works after resize
+      assert {:ok, metrics} = Finch.get_pool_status(finch_name, endpoint(bypass))
+      assert length(metrics) == 3
+
+      # Scale back down
+      assert :ok = Finch.set_pool_count(finch_name, endpoint(bypass), 2)
+      assert {:ok, 2} = Finch.get_pool_count(finch_name, endpoint(bypass))
+
+      assert {:ok, metrics} = Finch.get_pool_status(finch_name, endpoint(bypass))
+      assert length(metrics) == 2
+
+      # Requests work
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name)
+    end
+  end
+
   defp get_pools(name, pool) do
     Registry.lookup(name, Finch.Pool.to_name(pool))
   end


### PR DESCRIPTION
## Summary

- Add `Finch.get_pool_count/2` and `Finch.set_pool_count/3` for dynamically scaling pool workers at runtime without restarting the Finch instance
- Replace per-worker `persistent_term`/`atomics` metrics with a single ETS table per Finch instance, eliminating the global GC penalty of persistent_term writes when resizing pools
- Add `max_concurrent_streams` and `available_connections` to HTTP2 pool metrics
- Cleanup pool metrics when pools go down

## Motivation

Pool worker count was fixed at startup, requiring a full Finch restart to adjust capacity. During traffic spikes this means either over-provisioning upfront or accepting degraded performance.

The existing metrics implementation stored one `:persistent_term` entry and one `:atomics` array per worker. While fast for reads, this created many small entries that scale linearly with worker count and would make runtime resize problematic:
- removing a worker would remove its persistent_term entry, which would trigger a global GC on the entire node
- adding a worker would possibly trigger a full copy of the persistent-term table (that's how PT inserts work)

## Approach

### **Runtime resize**

Uses the existing static Supervisor's `start_child/2`, `terminate_child/2`, and `delete_child/2` APIs. Worker count is derived from `Supervisor.count_children/1` rather than cached in the registry, ensuring accuracy after resize. The pool config is stored in the supervisor registry value so new workers can be built with the correct spec.

It kinda tackles #313 (hello @PragTob 👋🏽), the topic about autoscaling, though it rather just makes autoscaling possible instead of dealing with scaling algorithms and hysteresis and thresholds and all that dance here, leaving this library thin. Note that on #313, we've also already implemented custom strategies too.

### **Metrics rewrite**

Replaces persistent_term/atomics with a single named ETS table per Finch instance using `read_concurrency: true, write_concurrency: :auto`. Each worker stores one row keyed by `{pool_name, pool_idx}` with positional metric values. Protocol-specific modules (HTTP1/HTTP2 PoolMetrics) own the row layout and position mapping; `Finch.PoolMetrics` owns key construction and ETS operations. Workers store `{table, pool_name, pool_idx}` as their metrics ref, avoiding table name derivation on the hot path.

### **HTTP2 `max_concurrent_streams`**
Is read from Mint's server settings on connection and after every `HTTP2.stream/2` call, skipped entirely when metrics are disabled.

### **Metrics cleanup**
Happens on scale-down (per-worker `:ets.delete`) and `stop_pool` (bulk `:ets.match_delete`), preventing orphaned entries (this solves #312 – hello @PragTob 👋🏽)