### PR TITLE
Validate keyword options in build/5 and request/3

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -804,6 +804,7 @@ defmodule Finch do
 
   def request(%Request{} = req, name, opts) do
     validate_no_req_body_fun!(req, "Finch.request/3")
+    Keyword.validate!(opts, [:pool_timeout, :receive_timeout, :request_timeout, :pool_strategy])
 
     request_span req, name do
       acc = {nil, [], [], []}

--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -110,6 +110,7 @@ defmodule Finch.Request do
   @doc false
   @spec build(method(), url(), headers(), body(), build_opts()) :: t()
   def build(method, url, headers, body, opts) do
+    Keyword.validate!(opts, [:unix_socket, :pool_tag])
     unix_socket = Keyword.get(opts, :unix_socket)
     pool_tag = Keyword.get(opts, :pool_tag, :default)
     {scheme, host, port, path, query} = parse_url(url)

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -171,6 +171,12 @@ defmodule FinchTest do
         Finch.build(:get, "ftp://example.com")
       end
     end
+
+    test "raises on invalid option", %{bypass: bypass} do
+      assert_raise ArgumentError, ~r/unknown keys \[:invalid_option\]/, fn ->
+        Finch.build(:get, endpoint(bypass), [], nil, invalid_option: true)
+      end
+    end
   end
 
   describe "request/3" do
@@ -620,6 +626,15 @@ defmodule FinchTest do
 
       assert {:ok, %Response{}} =
                Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name, pool_timeout: 1)
+    end
+
+    test "raises on invalid option", %{bypass: bypass, finch_name: finch_name} do
+      start_supervised!({Finch, name: finch_name})
+
+      assert_raise ArgumentError, ~r/unknown keys \[:unknown_option\]/, fn ->
+        Finch.build(:get, endpoint(bypass))
+        |> Finch.request(finch_name, unknown_option: true)
+      end
     end
   end
 


### PR DESCRIPTION
This is a suggestion in order to help catch typos or mistakes early.
For context, I spent some time debugging a timeout because I passed the `receive_timeout` to `build` instead of `request`.

I saw that `NimbleOptions` was used in other places, but I didn't want to go all the way in order to keep the change lightweight - happy to change it if it is the preferred way though.