### PR TITLE
Add Elixir Registry support for Finch instance naming

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -134,8 +134,13 @@ defmodule Finch do
 
   @typedoc """
   The `:name` provided to Finch in `start_link/1`.
+
+  Can be an atom (traditional) or a `{:via, Registry, {registry, key}}` tuple
+  for dynamic naming without atom creation. When using a via tuple, Finch
+  auto-generates an internal atom for its subsystems; users never need to
+  call `String.to_atom/1`.
   """
-  @type name() :: atom()
+  @type name() :: atom() | {:via, Registry, {atom(), term()}}
 
   @type scheme() :: :http | :https
 
@@ -334,19 +339,31 @@ defmodule Finch do
   """
   def start_link(opts) do
     name = finch_name!(opts)
+
+    {internal_name, supervisor_name, via_name} =
+      case name do
+        atom when is_atom(atom) ->
+          {atom, concat_name(atom, "Supervisor"), nil}
+
+        {:via, Registry, {_reg, _key}} = via ->
+          internal = Finch.NameRegistry.register(via)
+          {internal, via, via}
+      end
+
     pools = Keyword.get(opts, :pools, []) |> pool_options!()
     {default_pool_config, pools} = Map.pop(pools, :default)
 
     config = %{
-      registry_name: name,
+      registry_name: internal_name,
       registry_listeners: Keyword.get(opts, :registry_listeners, []),
-      supervisor_name: Pool.Manager.supervisor_name(name),
-      supervisor_registry_name: Pool.Manager.supervisor_registry_name(name),
+      supervisor_name: Pool.Manager.supervisor_name(internal_name),
+      supervisor_registry_name: Pool.Manager.supervisor_registry_name(internal_name),
       default_pool_config: default_pool_config,
-      pools: pools
+      pools: pools,
+      via_name: via_name
     }
 
-    Supervisor.start_link(__MODULE__, config, name: concat_name(name, "Supervisor"))
+    Supervisor.start_link(__MODULE__, config, name: supervisor_name)
   end
 
   @doc """
@@ -366,6 +383,8 @@ defmodule Finch do
   """
   @spec find_pool(name(), Finch.Pool.t()) :: {:ok, pid()} | :error
   def find_pool(name, %Finch.Pool{} = pool) do
+    name = resolve_finch_name(name)
+
     case Pool.Manager.get_pool(name, pool, %{start_pool?: false}) do
       {pid, _mod} -> {:ok, pid}
       _ -> :error
@@ -390,6 +409,8 @@ defmodule Finch do
   def start_pool(name, pool, opts \\ [])
 
   def start_pool(name, %Finch.Pool{} = pool, opts) do
+    name = resolve_finch_name(name)
+
     # Avoid building the child_spec (cast_pool_opts, sanitize, etc.) if the pool already exists
     if Process.whereis(name) do
       supervisor_registry_name = Pool.Manager.supervisor_registry_name(name)
@@ -423,22 +444,45 @@ defmodule Finch do
   def init(config) do
     Finch.PoolMetrics.new(config.registry_name)
 
-    children = [
-      {Registry,
-       keys: :duplicate,
-       name: config.registry_name,
-       listeners: config.registry_listeners,
-       meta: [config: config]},
-      {Registry, keys: :unique, name: config.supervisor_registry_name},
-      {DynamicSupervisor, name: config.supervisor_name, strategy: :one_for_one},
-      {Pool.Manager, config}
-    ]
+    via_cleaner =
+      if config.via_name do
+        [{Finch.ViaCleaner, config.via_name}]
+      else
+        []
+      end
+
+    children =
+      via_cleaner ++
+        [
+          {Registry,
+           keys: :duplicate,
+           name: config.registry_name,
+           listeners: config.registry_listeners,
+           meta: [config: config]},
+          {Registry, keys: :unique, name: config.supervisor_registry_name},
+          {DynamicSupervisor, name: config.supervisor_name, strategy: :one_for_one},
+          {Pool.Manager, config}
+        ]
 
     Supervisor.init(children, strategy: :one_for_all)
   end
 
   defp finch_name!(opts) do
-    Keyword.get(opts, :name) || raise(ArgumentError, "must supply a name")
+    case Keyword.get(opts, :name) do
+      nil ->
+        raise ArgumentError, "must supply a name"
+
+      name when is_atom(name) ->
+        name
+
+      {:via, Registry, {registry, _key}} = via when is_atom(registry) ->
+        via
+
+      other ->
+        raise ArgumentError,
+              "expected :name to be an atom or {:via, Registry, {registry, key}} tuple, " <>
+                "got: #{inspect(other)}"
+    end
   end
 
   defp pool_options!(pools) do
@@ -548,6 +592,8 @@ defmodule Finch do
 
   defp concat_name(name, suffix), do: :"#{name}.#{suffix}"
 
+  defp resolve_finch_name(name), do: Finch.NameRegistry.resolve(name)
+
   defmacrop request_span(request, name, do: block) do
     quote do
       start_meta = %{request: unquote(request), name: unquote(name)}
@@ -650,6 +696,7 @@ defmodule Finch do
           {:ok, acc} | {:error, Exception.t(), acc}
         when acc: term()
   def stream(%Request{} = req, name, acc, fun, opts \\ []) when is_function(fun, 2) do
+    name = resolve_finch_name(name)
     validate_no_req_body_fun!(req, "Finch.stream/5")
 
     fun = fn entry, acc ->
@@ -764,6 +811,8 @@ defmodule Finch do
           {:ok, acc} | {:error, Exception.t(), acc}
         when acc: term()
   def stream_while(%Request{} = req, name, acc, fun, opts \\ []) when is_function(fun, 2) do
+    name = resolve_finch_name(name)
+
     request_span req, name do
       __stream__(req, name, acc, fun, opts)
     end
@@ -805,6 +854,7 @@ defmodule Finch do
   def request(req, name, opts \\ [])
 
   def request(%Request{} = req, name, opts) do
+    name = resolve_finch_name(name)
     validate_no_req_body_fun!(req, "Finch.request/3")
 
     request_span req, name do
@@ -904,6 +954,7 @@ defmodule Finch do
   """
   @spec async_request(Request.t(), name(), request_opts()) :: request_ref()
   def async_request(%Request{} = req, name, opts \\ []) do
+    name = resolve_finch_name(name)
     validate_no_req_body_fun!(req, "Finch.async_request/3")
 
     case get_pool(req, name, opts) do
@@ -1002,6 +1053,8 @@ defmodule Finch do
           | {:error, :not_found}
 
   def get_pool_status(finch_name, :default) do
+    finch_name = resolve_finch_name(finch_name)
+
     finch_name
     |> Pool.Manager.get_default_pools()
     |> Enum.reduce(%{}, fn {sup_pid, {pool_name, pool_mod}}, acc ->
@@ -1023,6 +1076,7 @@ defmodule Finch do
   end
 
   def get_pool_status(finch_name, pool_identifier) do
+    finch_name = resolve_finch_name(finch_name)
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
@@ -1051,6 +1105,7 @@ defmodule Finch do
   """
   @spec ping(name(), pool_identifier()) :: {:ok, integer()} | {:error, term()}
   def ping(name, pool_identifier) do
+    name = resolve_finch_name(name)
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool(name, pool) do
@@ -1078,6 +1133,7 @@ defmodule Finch do
   """
   @spec stop_pool(name(), pool_identifier()) :: :ok | {:error, :not_found}
   def stop_pool(finch_name, pool_identifier) do
+    finch_name = resolve_finch_name(finch_name)
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
@@ -1102,6 +1158,7 @@ defmodule Finch do
   """
   @spec get_pool_count(name(), pool_identifier()) :: {:ok, pos_integer()} | {:error, :not_found}
   def get_pool_count(finch_name, pool_identifier) do
+    finch_name = resolve_finch_name(finch_name)
     pool = resolve_pool(pool_identifier)
 
     case Pool.Manager.get_pool_supervisor(finch_name, pool) do
@@ -1124,6 +1181,7 @@ defmodule Finch do
   """
   @spec set_pool_count(name(), pool_identifier(), pos_integer()) :: :ok | {:error, term()}
   def set_pool_count(finch_name, pool_identifier, count) when is_integer(count) and count > 0 do
+    finch_name = resolve_finch_name(finch_name)
     pool = resolve_pool(pool_identifier)
     Pool.Manager.set_pool_count(finch_name, pool, count)
   end

--- a/lib/finch/name_registry.ex
+++ b/lib/finch/name_registry.ex
@@ -1,0 +1,69 @@
+defmodule Finch.NameRegistry do
+  @moduledoc false
+
+  # Maps `{:via, Registry, {reg, key}}` tuples to auto-generated internal atoms.
+  #
+  # Finch's internals (Elixir Registry, named ETS tables) require atom identifiers.
+  # When a user provides a via tuple as the Finch name, this module generates a
+  # unique atom for internal use and stores the mapping in a shared ETS table.
+  #
+  # The generated atoms are bounded by the number of active Finch instances,
+  # not by user input, making this safe for dynamic/multi-tenant use cases.
+
+  @table :finch_via_names
+
+  @doc false
+  @spec ensure_table() :: :ok
+  def ensure_table do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+    end
+
+    :ok
+  end
+
+  @doc """
+  Generates a unique internal atom for the given via name and stores the mapping.
+  Returns the generated atom.
+  """
+  @spec register({:via, Registry, {atom(), term()}}) :: atom()
+  def register({:via, Registry, {_reg, _key}} = via_name) do
+    ensure_table()
+    internal = :"Finch.Instance.#{:erlang.unique_integer([:positive, :monotonic])}"
+    true = :ets.insert(@table, {via_name, internal})
+    internal
+  end
+
+  @doc """
+  Resolves a Finch name to the internal atom used by Finch's subsystems.
+
+  When given an atom, returns it unchanged (no-op).
+  When given a via tuple, looks up the internal atom from the ETS table.
+  """
+  @spec resolve(Finch.name()) :: atom()
+  def resolve(name) when is_atom(name), do: name
+
+  def resolve({:via, Registry, {_reg, _key}} = via_name) do
+    case :ets.lookup(@table, via_name) do
+      [{_, internal}] ->
+        internal
+
+      [] ->
+        raise ArgumentError,
+              "unknown Finch instance #{inspect(via_name)}. " <>
+                "Make sure the Finch instance is started before making requests."
+    end
+  end
+
+  @doc """
+  Removes the mapping for the given via name. Called during Finch shutdown.
+  """
+  @spec unregister({:via, Registry, {atom(), term()}}) :: :ok
+  def unregister({:via, Registry, {_reg, _key}} = via_name) do
+    if :ets.whereis(@table) != :undefined do
+      :ets.delete(@table, via_name)
+    end
+
+    :ok
+  end
+end

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -148,8 +148,14 @@ defmodule Finch.Pool.Manager do
           :not_found
 
         [{pid, {pool_mod, _pool_count, pool_config}}] ->
-          pool_count = Supervisor.count_children(pid).workers
-          {pid, pool_name, pool_mod, pool_count, pool_config}
+          # The pool supervisor may have been stopped between the Registry lookup
+          # and this call (e.g. after stop_pool/2). Guard against the race.
+          try do
+            pool_count = Supervisor.count_children(pid).workers
+            {pid, pool_name, pool_mod, pool_count, pool_config}
+          catch
+            :exit, {:noproc, _} -> :not_found
+          end
       end
     else
       :not_found

--- a/lib/finch/via_cleaner.ex
+++ b/lib/finch/via_cleaner.ex
@@ -1,0 +1,27 @@
+defmodule Finch.ViaCleaner do
+  @moduledoc false
+  use GenServer
+
+  # A tiny GenServer added as a child of the Finch supervision tree when
+  # the Finch instance is named with a `{:via, Registry, _}` tuple.
+  #
+  # Its only job is to remove the ETS mapping entry in `Finch.NameRegistry`
+  # when the Finch supervision tree shuts down, preventing stale entries.
+
+  @spec start_link({:via, Registry, {atom(), term()}}) :: GenServer.on_start()
+  def start_link(via_name) do
+    GenServer.start_link(__MODULE__, via_name)
+  end
+
+  @impl true
+  def init(via_name) do
+    Process.flag(:trap_exit, true)
+    {:ok, via_name}
+  end
+
+  @impl true
+  def terminate(_reason, via_name) do
+    Finch.NameRegistry.unregister(via_name)
+    :ok
+  end
+end

--- a/test/finch/http1/pool_test.exs
+++ b/test/finch/http1/pool_test.exs
@@ -52,8 +52,8 @@ defmodule Finch.HTTP1.PoolTest do
     Process.monitor(supervisor)
     Process.monitor(pool)
 
-    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}
-    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}
+    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 500
+    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}, 500
 
     assert [] = DynamicSupervisor.which_children(IdleFinch.PoolSupervisor)
     assert_receive :telemetry_sent
@@ -101,8 +101,8 @@ defmodule Finch.HTTP1.PoolTest do
     ref2 = make_ref()
     Task.async(fn -> delay_exec.(ref2, 10) end)
 
-    assert_receive {^ref1, :done}, 150
-    assert_receive {^ref2, :done}, 150
+    assert_receive {^ref1, :done}, 500
+    assert_receive {^ref2, :done}, 500
 
     [{_, supervisor, _, _}] = DynamicSupervisor.which_children(:"#{finch_name}.PoolSupervisor")
     Process.monitor(supervisor)
@@ -116,11 +116,11 @@ defmodule Finch.HTTP1.PoolTest do
 
     ref3 = make_ref()
     Task.async(fn -> assert {:ok, %{status: 200}} = delay_exec.(ref3, 10) end)
-    assert_receive {^ref3, :done}, 150
+    assert_receive {^ref3, :done}, 500
 
     refute_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 200
-    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 200
-    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}
+    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 500
+    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}, 500
   end
 
   # @tag capture_log: true
@@ -180,10 +180,10 @@ defmodule Finch.HTTP1.PoolTest do
     assert_receive {^ref2, :start}
     refute_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 1000
 
-    assert_receive {^ref2, :done}
-    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 200
+    assert_receive {^ref2, :done}, 500
+    assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :idle_timeout}}, 500
 
-    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}, 200
+    assert_receive {:DOWN, _, :process, ^supervisor, :shutdown}, 500
   end
 
   describe "async_request" do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2387,6 +2387,133 @@ defmodule FinchTest do
     end
   end
 
+  describe "Registry-based naming" do
+    setup %{bypass: bypass} do
+      via_registry = :"finch_via_test_#{System.unique_integer([:positive])}"
+      start_supervised!({Registry, keys: :unique, name: via_registry})
+      {:ok, bypass: bypass, via_registry: via_registry}
+    end
+
+    defp via_name(registry, key), do: {:via, Registry, {registry, key}}
+
+    test "start and make request with via tuple name", %{bypass: bypass, via_registry: reg} do
+      name = via_name(reg, "my-pool")
+      start_supervised!({Finch, name: name})
+
+      expect_any(bypass)
+
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(name)
+    end
+
+    test "multiple via-tuple instances can coexist", %{bypass: bypass, via_registry: reg} do
+      name1 = via_name(reg, "pool-1")
+      name2 = via_name(reg, "pool-2")
+      start_supervised!({Finch, name: name1}, id: :finch_via_1)
+      start_supervised!({Finch, name: name2}, id: :finch_via_2)
+
+      expect_any(bypass)
+
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(name1)
+
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(name2)
+    end
+
+    test "get_pool_status with via tuple name", %{bypass: bypass, via_registry: reg} do
+      name = via_name(reg, "status-pool")
+
+      start_supervised!(
+        {Finch,
+         name: name,
+         pools: %{
+           endpoint(bypass) => [size: 2, count: 1, start_pool_metrics?: true]
+         }}
+      )
+
+      assert {:ok, [%Finch.HTTP1.PoolMetrics{pool_size: 2}]} =
+               Finch.get_pool_status(name, endpoint(bypass))
+    end
+
+    test "get_pool_count and set_pool_count with via tuple name",
+         %{bypass: bypass, via_registry: reg} do
+      name = via_name(reg, "count-pool")
+
+      start_supervised!(
+        {Finch,
+         name: name,
+         pools: %{
+           endpoint(bypass) => [size: 2, count: 1]
+         }}
+      )
+
+      assert {:ok, 1} = Finch.get_pool_count(name, endpoint(bypass))
+      assert :ok = Finch.set_pool_count(name, endpoint(bypass), 3)
+      assert {:ok, 3} = Finch.get_pool_count(name, endpoint(bypass))
+    end
+
+    test "stop_pool with via tuple name", %{bypass: bypass, via_registry: reg} do
+      name = via_name(reg, "stop-pool")
+
+      start_supervised!(
+        {Finch,
+         name: name,
+         pools: %{
+           endpoint(bypass) => [size: 1, count: 1, start_pool_metrics?: true]
+         }}
+      )
+
+      assert {:ok, _metrics} = Finch.get_pool_status(name, endpoint(bypass))
+      assert :ok = Finch.stop_pool(name, endpoint(bypass))
+      assert Finch.stop_pool(name, "http://unknown:9999") == {:error, :not_found}
+    end
+
+    test "dynamic start_pool with via tuple name", %{bypass: bypass, via_registry: reg} do
+      name = via_name(reg, "dynamic-pool")
+      start_supervised!({Finch, name: name})
+
+      pool = Finch.Pool.new(endpoint(bypass))
+      assert :ok = Finch.start_pool(name, pool, size: 2)
+
+      expect_any(bypass)
+
+      assert {:ok, %Response{status: 200}} =
+               Finch.build(:get, endpoint(bypass)) |> Finch.request(name)
+    end
+
+    test "ETS mapping cleaned up after Finch stops", %{via_registry: reg} do
+      name = via_name(reg, "cleanup-pool")
+      start_supervised!({Finch, name: name}, id: :finch_cleanup_test)
+
+      # Mapping exists while Finch is running
+      assert is_atom(Finch.NameRegistry.resolve(name))
+
+      # Stop Finch
+      stop_supervised!(:finch_cleanup_test)
+
+      # Mapping should be cleaned up
+      assert_raise ArgumentError, ~r/unknown Finch instance/, fn ->
+        Finch.NameRegistry.resolve(name)
+      end
+    end
+
+    test "supervisor is discoverable via the user's Registry", %{via_registry: reg} do
+      name = via_name(reg, "discoverable")
+      start_supervised!({Finch, name: name})
+
+      assert [{pid, _}] = Registry.lookup(reg, "discoverable")
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+    end
+
+    test "raises on invalid name shape" do
+      assert_raise ArgumentError, ~r/expected :name to be an atom/, fn ->
+        Finch.start_link(name: {"not", "valid"})
+      end
+    end
+  end
+
   defp get_pools(name, pool) do
     Registry.lookup(name, Finch.Pool.to_name(pool))
   end


### PR DESCRIPTION
## Add Elixir Registry support for Finch instance naming

### Problem

Finch only accepts `atom()` for the `:name` option in `start_link/1`. This forces
users who dynamically create Finch pools from runtime configuration (e.g., config
files, databases, multi-tenant setups) to use `String.to_atom/1`, which leaks atoms
since the BEAM never garbage-collects them. This is a well-known footgun for any
system with unbounded dynamic names.

### Solution

Allow `{:via, Registry, {registry, key}}` tuples as the `:name` option, following
the standard Elixir convention for dynamic process naming without atom creation.

```elixir
# Before (atom leak from dynamic input):
name = String.to_atom("finch_#{tenant_id}")
Finch.start_link(name: name)
Finch.request(req, name)

# After (safe, no atom creation from user input):
name = {:via, Registry, {MyApp.FinchRegistry, tenant_id}}
Finch.start_link(name: name)
Finch.request(req, name)
```

### Design

Finch's internals (Elixir `Registry.lookup/2`, named ETS tables) require atom
identifiers — this is a hard constraint from the BEAM and Elixir's `Registry`
module (`@type registry :: atom`). The solution introduces a thin indirection
layer:

1. **`Finch.NameRegistry`** — a shared ETS table (`:finch_via_names`) that maps
   `{:via, Registry, {reg, key}}` tuples to auto-generated internal atoms
   (e.g., `:"Finch.Instance.42"`). These atoms are bounded by the number of
   active Finch instances, not by user input.

2. **`Finch.ViaCleaner`** — a tiny GenServer added as a child of the Finch
   supervision tree (only when using via tuples) that removes the ETS mapping
   entry on termination, preventing stale entries.

3. **`resolve_finch_name/1`** — called at the entry point of every public API
   function. For atoms it's a no-op passthrough; for via tuples it resolves to
   the internal atom via the ETS lookup.

### What changes

| File | Change |
|------|--------|
| `lib/finch/name_registry.ex` | **New** — ETS-backed via→atom mapping (register/resolve/unregister) |
| `lib/finch/via_cleaner.ex` | **New** — GenServer that cleans up ETS entry on shutdown |
| `lib/finch.ex` | Update `@type name()`, `start_link/1`, `init/1`, `finch_name!/1`; add `resolve_finch_name/1`; wire resolution into all public API functions |
| `lib/finch/pool/manager.ex` | Fix race in `get_pool_supervisor/2`: catch `:noproc` exit when supervisor dies between Registry lookup and `Supervisor.count_children/1` |
| `test/finch_test.exs` | New `"Registry-based naming"` describe block with tests |
| `test/finch/http1/pool_test.exs` | Fix flaky idle-timeout tests: increase `assert_receive` timeouts from 100-150ms to 500ms |

### What stays unchanged

- All internal modules (`Pool.Manager`, `Pool.Supervisor`, `HTTP1.Pool`,
  `HTTP2.Pool`, `PoolMetrics`) — they only ever receive atoms after resolution
- All existing atom-based naming — 100% backward compatible
- Zero performance impact on atom-named instances (`resolve_finch_name/1` for
  atoms is a single pattern match)

### Tests

- Start Finch with via tuple, make HTTP/1 request
- Multiple via-tuple instances coexisting
- `get_pool_status/2` with via tuple name
- Dynamic `start_pool/3` with via tuple name
- `stop_pool/2` with via tuple name
- `get_pool_count/2` and `set_pool_count/3` with via tuple name
- ETS cleanup: entry removed after Finch stops
- Supervisor discoverable via user's Registry
- Validation: raises on invalid name shape

### Flaky test fixes

- **`get_pool_supervisor/2` race condition** — `Supervisor.count_children/1` was
  called on a PID obtained from `Registry.lookup/2` without guarding against the
  supervisor dying between lookup and call. Fixed by catching `:noproc` exits and
  returning `:not_found`.

- **HTTP1 pool idle timeout tests** — `assert_receive` timeouts of 100-150ms were
  too tight under parallel test load. Increased to 500ms. The `refute_receive`
  timeouts (which test that something does NOT happen within a window) are left
  unchanged since they need to be tight to be meaningful.