### PR TITLE
Pool metrics improvements

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -1004,10 +1004,8 @@ defmodule Finch do
   def get_pool_status(finch_name, :default) do
     finch_name
     |> Pool.Manager.get_default_pools()
-    |> Enum.reduce(%{}, fn {sup_pid, {pool_name, pool_mod}}, acc ->
-      pool_count = Supervisor.count_children(sup_pid).workers
-
-      case pool_mod.get_pool_status(finch_name, pool_name, pool_count) do
+    |> Enum.reduce(%{}, fn {_sup_pid, {pool_name, pool_mod}}, acc ->
+      case pool_mod.get_pool_status(finch_name, pool_name) do
         {:ok, metrics} ->
           pool_id = Pool.from_name(pool_name)
           Map.put(acc, pool_id, metrics)
@@ -1025,9 +1023,9 @@ defmodule Finch do
   def get_pool_status(finch_name, pool_identifier) do
     pool = resolve_pool(pool_identifier)
 
-    case Pool.Manager.get_pool_supervisor(finch_name, pool) do
-      {_pid, pool_name, pool_mod, pool_count, _pool_config} ->
-        pool_mod.get_pool_status(finch_name, pool_name, pool_count)
+    case Pool.Manager.get_pool_mod(finch_name, pool) do
+      {pool_name, pool_mod} ->
+        pool_mod.get_pool_status(finch_name, pool_name)
 
       :not_found ->
         {:error, :not_found}

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -996,7 +996,7 @@ defmodule Finch do
          ]
        }}
   """
-  @spec get_pool_status(name(), pool_identifier()) ::
+  @spec get_pool_status(name(), :default | pool_identifier()) ::
           {:ok, pool_metrics()}
           | {:ok, default_pool_metrics()}
           | {:error, :not_found}

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -145,16 +145,7 @@ defmodule Finch.HTTP1.Pool do
   end
 
   @impl Finch.Pool.Manager
-  def get_pool_status(finch_name, pool_name, count) do
-    for index <- 1..count,
-        {:ok, result} <- [PoolMetrics.get_pool_status(finch_name, pool_name, index)] do
-      result
-    end
-    |> case do
-      [] -> {:error, :not_found}
-      result -> {:ok, result}
-    end
-  end
+  defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
   @impl NimblePool
   def init_pool({pool, pool_name, registry, pool_config, pool_idx}) do

--- a/lib/finch/http1/pool_metrics.ex
+++ b/lib/finch/http1/pool_metrics.ex
@@ -47,22 +47,22 @@ defmodule Finch.HTTP1.PoolMetrics do
     PoolMetrics.update(table, pool_name, pool_idx, @pos_in_use, delta)
   end
 
-  def get_pool_status(finch_name, pool_name, pool_idx) do
-    table = PoolMetrics.table_name(finch_name)
-
-    case PoolMetrics.get_row(table, pool_name, pool_idx) do
-      nil ->
+  def get_pool_status(finch_name, pool_name) do
+    case PoolMetrics.get_all_rows(finch_name, pool_name) do
+      [] ->
         {:error, :not_found}
 
-      {_key, pool_size, in_use, pid} ->
+      rows ->
         {:ok,
-         %__MODULE__{
-           pid: pid,
-           pool_index: pool_idx,
-           pool_size: pool_size,
-           available_connections: pool_size - in_use,
-           in_use_connections: in_use
-         }}
+         Enum.map(rows, fn {{_pool_name, pool_idx}, pool_size, in_use, pid} ->
+           %__MODULE__{
+             pid: pid,
+             pool_index: pool_idx,
+             pool_size: pool_size,
+             available_connections: pool_size - in_use,
+             in_use_connections: in_use
+           }
+         end)}
     end
   end
 end

--- a/lib/finch/http1/pool_metrics.ex
+++ b/lib/finch/http1/pool_metrics.ex
@@ -4,6 +4,7 @@ defmodule Finch.HTTP1.PoolMetrics do
 
   Available metrics:
 
+    * `:pid` - The pid of the pool worker process
     * `:pool_index` - Index of the pool
     * `:pool_size` - Total number of connections of the pool
     * `:available_connections` - Number of available connections
@@ -22,6 +23,7 @@ defmodule Finch.HTTP1.PoolMetrics do
   @type t :: %__MODULE__{}
 
   defstruct [
+    :pid,
     :pool_index,
     :pool_size,
     :available_connections,
@@ -30,12 +32,12 @@ defmodule Finch.HTTP1.PoolMetrics do
 
   alias Finch.PoolMetrics
 
-  # Row layout: {{pool_name, pool_idx}, pool_size, in_use_connections}
+  # Row layout: {{pool_name, pool_idx}, pool_size, in_use_connections, pid}
   @pos_in_use 3
 
   def init(finch_name, pool_name, pool_idx, pool_size) do
     table = PoolMetrics.table_name(finch_name)
-    PoolMetrics.insert(table, pool_name, pool_idx, [pool_size, 0])
+    PoolMetrics.insert(table, pool_name, pool_idx, [pool_size, 0, self()])
     {:ok, {table, pool_name, pool_idx}}
   end
 
@@ -52,9 +54,10 @@ defmodule Finch.HTTP1.PoolMetrics do
       nil ->
         {:error, :not_found}
 
-      {_key, pool_size, in_use} ->
+      {_key, pool_size, in_use, pid} ->
         {:ok,
          %__MODULE__{
+           pid: pid,
            pool_index: pool_idx,
            pool_size: pool_size,
            available_connections: pool_size - in_use,

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -90,16 +90,7 @@ defmodule Finch.HTTP2.Pool do
   end
 
   @impl Finch.Pool.Manager
-  def get_pool_status(finch_name, pool_name, count) do
-    for index <- 1..count,
-        {:ok, result} <- [PoolMetrics.get_pool_status(finch_name, pool_name, index)] do
-      result
-    end
-    |> case do
-      [] -> {:error, :not_found}
-      result -> {:ok, result}
-    end
-  end
+  defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
   defp make_request_ref(pool) do
     {__MODULE__, {pool, make_ref()}}

--- a/lib/finch/http2/pool_metrics.ex
+++ b/lib/finch/http2/pool_metrics.ex
@@ -55,22 +55,22 @@ defmodule Finch.HTTP2.PoolMetrics do
   end
 
   @doc false
-  def get_pool_status(finch_name, pool_name, pool_idx) do
-    table = PoolMetrics.table_name(finch_name)
-
-    case PoolMetrics.get_row(table, pool_name, pool_idx) do
-      nil ->
+  def get_pool_status(finch_name, pool_name) do
+    case PoolMetrics.get_all_rows(finch_name, pool_name) do
+      [] ->
         {:error, :not_found}
 
-      {_key, in_flight, max_streams, pid} ->
+      rows ->
         {:ok,
-         %__MODULE__{
-           pid: pid,
-           pool_index: pool_idx,
-           in_flight_requests: in_flight,
-           available_connections: max_streams - in_flight,
-           max_concurrent_streams: max_streams
-         }}
+         Enum.map(rows, fn {{_pool_name, pool_idx}, in_flight, max_streams, pid} ->
+           %__MODULE__{
+             pid: pid,
+             pool_index: pool_idx,
+             in_flight_requests: in_flight,
+             available_connections: max_streams - in_flight,
+             max_concurrent_streams: max_streams
+           }
+         end)}
     end
   end
 end

--- a/lib/finch/http2/pool_metrics.ex
+++ b/lib/finch/http2/pool_metrics.ex
@@ -4,6 +4,7 @@ defmodule Finch.HTTP2.PoolMetrics do
 
   Available metrics:
 
+    * `:pid` - The pid of the pool worker process
     * `:pool_index` - Index of the pool
     * `:in_flight_requests` - Number of requests currently on the connection
     * `:available_connections` - Number of available connections
@@ -19,6 +20,7 @@ defmodule Finch.HTTP2.PoolMetrics do
   @type t :: %__MODULE__{}
 
   defstruct [
+    :pid,
     :pool_index,
     :in_flight_requests,
     :available_connections,
@@ -27,14 +29,14 @@ defmodule Finch.HTTP2.PoolMetrics do
 
   alias Finch.PoolMetrics
 
-  # Row layout: {{pool_name, pool_idx}, in_flight_requests, max_concurrent_streams}
+  # Row layout: {{pool_name, pool_idx}, in_flight_requests, max_concurrent_streams, pid}
   @pos_in_flight 2
   @pos_max_streams 3
 
   @doc false
   def init(finch_name, pool_name, pool_idx) do
     table = PoolMetrics.table_name(finch_name)
-    PoolMetrics.insert(table, pool_name, pool_idx, [0, 0])
+    PoolMetrics.insert(table, pool_name, pool_idx, [0, 0, self()])
     {:ok, {table, pool_name, pool_idx}}
   end
 
@@ -60,9 +62,10 @@ defmodule Finch.HTTP2.PoolMetrics do
       nil ->
         {:error, :not_found}
 
-      {_key, in_flight, max_streams} ->
+      {_key, in_flight, max_streams, pid} ->
         {:ok,
          %__MODULE__{
+           pid: pid,
            pool_index: pool_idx,
            in_flight_requests: in_flight,
            available_connections: max_streams - in_flight,

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -32,7 +32,7 @@ defmodule Finch.Pool.Manager do
   @callback cancel_async_request(request_ref()) :: :ok
 
   @doc false
-  @callback get_pool_status(finch_name :: atom(), pool_name(), pos_integer) ::
+  @callback get_pool_status(finch_name :: atom(), pool_name()) ::
               {:ok, list(map)} | {:error, :not_found}
 
   @doc false
@@ -150,6 +150,24 @@ defmodule Finch.Pool.Manager do
         [{pid, {pool_mod, _pool_count, pool_config}}] ->
           pool_count = Supervisor.count_children(pid).workers
           {pid, pool_name, pool_mod, pool_count, pool_config}
+      end
+    else
+      :not_found
+    end
+  end
+
+  @spec get_pool_mod(Finch.name(), Finch.Pool.t()) ::
+          {pool_name(), module()} | :not_found
+  def get_pool_mod(finch_name, %Finch.Pool{} = pool) do
+    pool_name = Finch.Pool.to_name(pool)
+
+    if Process.whereis(finch_name) do
+      case Registry.lookup(supervisor_registry_name(finch_name), pool_name) do
+        [{_pid, {pool_mod, _pool_count, _pool_config}}] ->
+          {pool_name, pool_mod}
+
+        [] ->
+          :not_found
       end
     else
       :not_found

--- a/lib/finch/pool_metrics.ex
+++ b/lib/finch/pool_metrics.ex
@@ -84,6 +84,6 @@ defmodule Finch.PoolMetrics do
   @spec delete_pool(atom(), term()) :: true
   def delete_pool(finch_name, pool_name) do
     table = table_name(finch_name)
-    :ets.match_delete(table, {{pool_name, :_}, :_, :_})
+    :ets.match_delete(table, {{pool_name, :_}, :_, :_, :_})
   end
 end

--- a/lib/finch/pool_metrics.ex
+++ b/lib/finch/pool_metrics.ex
@@ -23,7 +23,7 @@ defmodule Finch.PoolMetrics do
   @spec new(atom()) :: :ets.table()
   def new(finch_name) do
     :ets.new(table_name(finch_name), [
-      :set,
+      :ordered_set,
       :public,
       :named_table,
       read_concurrency: true,
@@ -59,14 +59,13 @@ defmodule Finch.PoolMetrics do
   end
 
   @doc """
-  Reads the full metrics row for the given key. Returns `nil` if not found.
+  Returns all metrics rows for the given pool_name, using ordered_set prefix lookup.
   """
-  @spec get_row(atom(), term(), pos_integer()) :: tuple() | nil
-  def get_row(table, pool_name, pool_idx) do
-    case :ets.lookup(table, {pool_name, pool_idx}) do
-      [row] -> row
-      [] -> nil
-    end
+  @spec get_all_rows(Finch.name(), term()) :: [tuple()]
+  def get_all_rows(table, pool_name) do
+    table
+    |> table_name()
+    |> :ets.match_object({{pool_name, :_}, :_, :_, :_})
   end
 
   @doc """

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2339,7 +2339,7 @@ defmodule FinchTest do
       # All metrics should be cleaned up
       table = Finch.PoolMetrics.table_name(finch_name)
       pool_name = Finch.Pool.to_name(pool(bypass))
-      assert :ets.match(table, {{pool_name, :_}, :_, :_}) == []
+      assert :ets.match(table, {{pool_name, :_}, :_, :_, :_}) == []
     end
 
     test "resizing a materialized default pool updates :default pool metrics", %{


### PR DESCRIPTION
Somewhat a follow up on https://github.com/sneako/finch/pull/362, having the pid on the metrics could help me correlate load to processes. Also, reworked the implementation to use `ordered_set` ets tables, which allow to use prefix lookups, hence skipping a supervisor call and replace `count`-ets-lookups with a single one.