### PR TITLE
Support for HTTP/2  per-chunk idle receive_timeout and wall clock request_timeout 

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -849,10 +849,8 @@ defmodule Finch do
     * `:receive_timeout` - The maximum time to wait for each chunk to be received before returning an error.
       Default value is `15_000`.
 
-    * `:request_timeout` - The amount of time to wait for a complete response before returning an error.
-      This timeout only applies to HTTP/1, and its current implementation is a best effort timeout,
-      it does not guarantee the call will return precisely when the time has elapsed.
-      Default value is `:infinity`.
+    * `:request_timeout` - The total wall-clock time to wait for a complete response before returning
+      an error. Default value is `:infinity`.
 
     * `:pool_strategy` - When the pool has multiple shards (`count: N`), selects which shards handles
       the request. Default is random selection. See `t:pool_strategy/0` for details.

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -41,18 +41,17 @@ defmodule Finch.HTTP2.Pool do
 
   def request(pool, request, acc, fun, name, opts) do
     opts = Keyword.put_new(opts, :receive_timeout, @default_receive_timeout)
-    timeout = opts[:receive_timeout]
     request_ref = make_request_ref(pool)
 
     case :gen_statem.call(pool, {:request, request_ref, request, opts}) do
       {:ok, recv_start} ->
         monitor = Process.monitor(pool)
         # If the timeout is an integer, we add a fail-safe "after" clause that fires
-        # after a timeout that is double the original timeout (min 2000ms). This means
-        # that if there are no bugs in our code, then the normal :request_timeout is
-        # returned, but otherwise we have a way to escape this code, raise an error, and
-        # get the process unstuck.
-        fail_safe_timeout = if is_integer(timeout), do: max(2000, timeout * 2), else: :infinity
+        # after a timeout that is double the largest timeout (min 2000ms). This means
+        # that if there are no bugs in our code, then the normal timeout is returned,
+        # but otherwise we have a way to escape this code, raise an error, and get
+        # the process unstuck.
+        fail_safe_timeout = fail_safe_timeout(opts)
 
         try do
           response_waiting_loop(acc, fun, request_ref, monitor, fail_safe_timeout, :headers)
@@ -338,6 +337,10 @@ defmodule Finch.HTTP2.Pool do
   # some timeouts might fire while changing states, so we need to handle them here.
   # Since we replied to all pending requests when entering the :disconnected state,
   # we can just do nothing here.
+  def disconnected({:timeout, {:receive_timeout, _ref}}, _content, _data) do
+    :keep_state_and_data
+  end
+
   def disconnected({:timeout, {:request_timeout, _ref}}, _content, _data) do
     :keep_state_and_data
   end
@@ -483,34 +486,14 @@ defmodule Finch.HTTP2.Pool do
     end
   end
 
+  # Idle timeout: no data received within receive_timeout interval
+  def connected({:timeout, {:receive_timeout, ref}}, _content, data) do
+    handle_request_timeout(data, ref)
+  end
+
+  # Total wall-clock timeout: request exceeded request_timeout
   def connected({:timeout, {:request_timeout, ref}}, _content, data) do
-    with {:pop, {request, data}} when not is_nil(request) <- {:pop, pop_request(data, ref)},
-         {:ok, conn} <- HTTP2.cancel_request(data.conn, ref) do
-      data = put_in(data.conn, conn)
-      send(request.from_pid, {request.request_ref, {:error, Error.exception(:request_timeout)}})
-      {:keep_state, data}
-    else
-      {:error, conn, _error} ->
-        data = put_in(data.conn, conn)
-
-        cond do
-          HTTP2.open?(conn, :write) ->
-            {:keep_state, data}
-
-          # Don't bother entering read only mode if we don't have any pending requests.
-          HTTP2.open?(conn, :read) && Enum.any?(data.requests) ->
-            {:next_state, :connected_read_only, data}
-
-          true ->
-            {:next_state, :disconnected, data}
-        end
-
-      # The timer might have fired while we were receiving :done/:error for this
-      # request, so we don't have the request stored anymore but we still get the
-      # timer event. In those cases, we do nothing.
-      {:pop, {nil, _data}} ->
-        :keep_state_and_data
-    end
+    handle_request_timeout(data, ref)
   end
 
   # The connection has exceeded its maximum age. Unregister from the Registry so
@@ -663,21 +646,24 @@ defmodule Finch.HTTP2.Pool do
 
   # In this state, we don't need to call HTTP2.cancel_request/2 since the connection
   # is closed for writing, so we can't tell the server to cancel the request anymore.
+  def connected_read_only({:timeout, {:receive_timeout, ref}}, _content, data) do
+    handle_read_only_timeout(data, ref)
+  end
+
   def connected_read_only({:timeout, {:request_timeout, ref}}, _content, data) do
-    # We might get a request timeout that fired in the moment when we received the
-    # whole request, so we don't have the request in the state but we get the
-    # timer event anyways. In those cases, we don't do anything.
+    handle_read_only_timeout(data, ref)
+  end
+
+  defp handle_read_only_timeout(data, ref) do
+    # The timer might have fired in the moment when we received the whole
+    # request, so we don't have the request stored anymore. In those cases,
+    # we don't do anything.
     {request, data} = pop_request(data, ref)
 
-    # Its possible that the request doesn't exist so we guard against that here.
     if request != nil do
       send(request.from_pid, {request.request_ref, {:error, Error.exception(:request_timeout)}})
     end
 
-    # If requests remain, keep waiting for their responses. If the pool is
-    # draining and all requests are done, stop normally so the supervisor
-    # restarts it with a fresh DNS lookup. Otherwise enter the disconnected
-    # state so we can try to re-establish a connection.
     cond do
       Enum.any?(data.requests) ->
         {:keep_state, data}
@@ -698,6 +684,8 @@ defmodule Finch.HTTP2.Pool do
       from: from,
       from_pid: from_pid,
       request_ref: request_ref,
+      receive_timeout: opts[:receive_timeout] || @default_receive_timeout,
+      request_timeout: opts[:request_timeout] || :infinity,
       telemetry: %{
         metadata: telemetry_metadata,
         send: Telemetry.start(:send, telemetry_metadata)
@@ -721,18 +709,20 @@ defmodule Finch.HTTP2.Pool do
     end
   end
 
-  defp stream_request({:ok, data, ref}, request, opts) do
+  defp stream_request({:ok, data, ref}, request, _opts) do
     data = put_request(data, ref, request)
 
     case continue_request(data, ref, request) do
       {:ok, data} ->
-        # Set a timeout to close the request after a given timeout
-        request_timeout = {{:timeout, {:request_timeout, ref}}, opts[:receive_timeout], nil}
+        # Idle timeout: re-armed on each data chunk (see handle_response for :data)
+        idle_timeout = {{:timeout, {:receive_timeout, ref}}, request.receive_timeout, nil}
+        # Total wall-clock cap (one-shot, never re-armed)
+        total_timeout = {{:timeout, {:request_timeout, ref}}, request.request_timeout, nil}
 
-        {:keep_state, data, [request_timeout, ping_action(data)]}
+        {:keep_state, data, [idle_timeout, total_timeout, ping_action(data)]}
 
       error ->
-        stream_request(error, request, opts)
+        stream_request(error, request, nil)
     end
   end
 
@@ -779,9 +769,12 @@ defmodule Finch.HTTP2.Pool do
   defp handle_response(data, {:data, ref, value}, actions) do
     if request = data.requests[ref] do
       send(request.from_pid, {request.request_ref, {:data, value}})
+      # Re-arm the idle timeout on each chunk so it acts as an inter-chunk timeout
+      rearm = {{:timeout, {:receive_timeout, ref}}, request.receive_timeout, nil}
+      {data, [rearm | actions]}
+    else
+      {data, actions}
     end
-
-    {data, actions}
   end
 
   defp handle_response(data, {:done, ref}, actions) do
@@ -792,7 +785,7 @@ defmodule Finch.HTTP2.Pool do
       Telemetry.stop(:recv, request.telemetry.recv, request.telemetry.metadata)
     end
 
-    {data, [cancel_request_timeout_action(ref) | actions]}
+    {data, cancel_request_timeout_actions(ref, actions)}
   end
 
   defp handle_response(data, {:pong, ref}, actions) do
@@ -820,13 +813,54 @@ defmodule Finch.HTTP2.Pool do
       )
     end
 
-    {data, [cancel_request_timeout_action(ref) | actions]}
+    {data, cancel_request_timeout_actions(ref, actions)}
   end
 
-  defp cancel_request_timeout_action(request_ref) do
+  defp cancel_request_timeout_actions(request_ref, actions) do
     # By setting the timeout to :infinity, we cancel this timeout as per
     # gen_statem documentation.
-    {{:timeout, {:request_timeout, request_ref}}, :infinity, nil}
+    [
+      {{:timeout, {:receive_timeout, request_ref}}, :infinity, nil},
+      {{:timeout, {:request_timeout, request_ref}}, :infinity, nil}
+      | actions
+    ]
+  end
+
+  defp fail_safe_timeout(opts) do
+    receive_timeout = opts[:receive_timeout]
+    request_timeout = opts[:request_timeout]
+
+    cond do
+      is_integer(request_timeout) -> max(2000, request_timeout * 2)
+      is_integer(receive_timeout) -> max(2000, receive_timeout * 2)
+      true -> :infinity
+    end
+  end
+
+  defp handle_request_timeout(data, ref) do
+    with {:pop, {request, data}} when not is_nil(request) <- {:pop, pop_request(data, ref)},
+         {:ok, conn} <- HTTP2.cancel_request(data.conn, ref) do
+      data = put_in(data.conn, conn)
+      send(request.from_pid, {request.request_ref, {:error, Error.exception(:request_timeout)}})
+      {:keep_state, data}
+    else
+      {:error, conn, _error} ->
+        data = put_in(data.conn, conn)
+
+        cond do
+          HTTP2.open?(conn, :write) ->
+            {:keep_state, data}
+
+          HTTP2.open?(conn, :read) && Enum.any?(data.requests) ->
+            {:next_state, :connected_read_only, data}
+
+          true ->
+            {:next_state, :disconnected, data}
+        end
+
+      {:pop, {nil, _data}} ->
+        :keep_state_and_data
+    end
   end
 
   # Exponential backoff with jitter

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -223,7 +223,7 @@ defmodule Finch.HTTP2.PoolTest do
       assert_receive {:result, {:ok, {200, [], "ok"}}}
     end
 
-    test "request timeout with timeout of 0", %{request: req} do
+    test "receive timeout with timeout of 0", %{request: req} do
       us = self()
 
       {:ok, pool} =
@@ -241,7 +241,7 @@ defmodule Finch.HTTP2.PoolTest do
       assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
     end
 
-    test "request timeout with timeout > 0", %{request: req} do
+    test "receive timeout with timeout > 0", %{request: req} do
       us = self()
 
       {:ok, pool} =
@@ -292,7 +292,7 @@ defmodule Finch.HTTP2.PoolTest do
       refute_receive _any, 200
     end
 
-    test "request timeout with timeout > 0 where :done arrives after timeout", %{request: req} do
+    test "receive timeout with timeout > 0 where :done arrives after timeout", %{request: req} do
       us = self()
 
       {:ok, pool} =
@@ -322,6 +322,68 @@ defmodule Finch.HTTP2.PoolTest do
       assert_recv_frames([rst_stream(stream_id: ^stream_id, error_code: :cancel)])
 
       assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}
+    end
+
+    test "receive timeout resets on each data chunk", %{request: req} do
+      us = self()
+
+      {:ok, pool} =
+        start_server_and_connect_with(fn port ->
+          start_pool(port)
+        end)
+
+      spawn(fn ->
+        resp = request(pool, req, receive_timeout: 100, request_timeout: :infinity)
+        send(us, {:resp, resp})
+      end)
+
+      assert_recv_frames([headers(stream_id: stream_id)])
+
+      hbf = server_encode_headers([{":status", "200"}])
+
+      server_send_frames([
+        headers(stream_id: stream_id, hbf: hbf, flags: set_flags(:headers, [:end_headers]))
+      ])
+
+      # Send 3 chunks spaced 50ms apart. Total ~150ms exceeds receive_timeout
+      # of 100ms, but each chunk arrives within the window.
+      for i <- 1..3 do
+        Process.sleep(50)
+        flags = if i == 3, do: set_flags(:data, [:end_stream]), else: 0x00
+        server_send_frames([data(stream_id: stream_id, data: "chunk-#{i}", flags: flags)])
+      end
+
+      assert_receive {:resp, {:ok, _}}, 500
+    end
+
+    test "request_timeout fires when total duration is exceeded", %{request: req} do
+      us = self()
+
+      {:ok, pool} =
+        start_server_and_connect_with(fn port ->
+          start_pool(port)
+        end)
+
+      spawn(fn ->
+        resp = request(pool, req, receive_timeout: 500, request_timeout: 100)
+        send(us, {:resp, resp})
+      end)
+
+      assert_recv_frames([headers(stream_id: stream_id)])
+
+      hbf = server_encode_headers([{":status", "200"}])
+
+      server_send_frames([
+        headers(stream_id: stream_id, hbf: hbf, flags: set_flags(:headers, [:end_headers]))
+      ])
+
+      # Chunks keep idle timeout alive but total time exceeds request_timeout
+      for i <- 1..3 do
+        Process.sleep(50)
+        server_send_frames([data(stream_id: stream_id, data: "chunk-#{i}", flags: 0x00)])
+      end
+
+      assert_receive {:resp, {:error, %Finch.Error{reason: :request_timeout}, _acc}}, 500
     end
   end
 


### PR DESCRIPTION
**Description**
`Finch`'s HTTP/2 `receive_timeout` was a one-shot timer at request start. It never reset when data arrived. Streaming responses that took longer than `receive_timeout` (even with chunks coming in) would get killed. These changes bring it in line with the opts for HTTP/1.

HTTP/1 doesn't have this issue because `receive_timeout` is passed per `Mint.HTTP.recv()` call.

_This is a breaking change, users who just pass in `receive_timeout` will have the default `request_timeout` (infinity) still. This means a user may not receive timeouts as expected._

**Changes**
- `receive_timeout` is now an idle timeout that is reset on every `:data` chunk in `handle_response`
- `request_timeout` can now be used for a "wall-clock" cap timeout
- Refactor the timeout request handling for both cases