### PR TITLE
Fix source field typespecs in HTTPError and TransportError

### DIFF
--- a/lib/finch/http_error.ex
+++ b/lib/finch/http_error.ex
@@ -8,7 +8,7 @@ defmodule Finch.HTTPError do
   @type t() :: %__MODULE__{
           reason: reason(),
           module: module() | nil,
-          source: Mint.HTTPError.t() | nil
+          source: Exception.t() | nil
         }
 
   defexception [:reason, :module, :source]

--- a/lib/finch/transport_error.ex
+++ b/lib/finch/transport_error.ex
@@ -5,7 +5,7 @@ defmodule Finch.TransportError do
 
   @type reason() :: Mint.TransportError.reason()
 
-  @type t() :: %__MODULE__{reason: reason(), source: Mint.TransportError.t() | nil}
+  @type t() :: %__MODULE__{reason: reason(), source: Exception.t() | nil}
 
   defexception [:reason, :source]
 


### PR DESCRIPTION
The `source` field in `Finch.HTTPError` and `Finch.TransportError` was typed as `Mint.HTTPError.t() | nil` and `Mint.TransportError.t() | nil` respectively. The set-theoretic type checker surfaced by elixir-lang/elixir#15366 treats `@type t()` definitions as closed-map types. Because `Mint.HTTPError.t()` only declares `{reason: reason()}` and omits the `:module` field present in the actual struct, a value matched with `%Mint.HTTPError{reason: reason, module: module} = error` carries a `:module` field that falls outside the declared type. This produces a `:badstructfield` diagnostic for the `:source` field at the construction site.

The `:source` field holds the original Mint exception so that `Exception.message/1` can delegate to it. `Exception.t()` is the accurate type for that usage: it is an open-map type that admits any exception struct, including both `Mint.HTTPError` and `Mint.TransportError`.

**Before:**

```elixir
# http_error.ex
@type t() :: %__MODULE__{
        reason: reason(),
        module: module() | nil,
        source: Mint.HTTPError.t() | nil
      }

# transport_error.ex
@type t() :: %__MODULE__{reason: reason(), source: Mint.TransportError.t() | nil}
```

**After:**

```elixir
# http_error.ex
@type t() :: %__MODULE__{
        reason: reason(),
        module: module() | nil,
        source: Exception.t() | nil
      }

# transport_error.ex
@type t() :: %__MODULE__{reason: reason(), source: Exception.t() | nil}
```

`mix test`: 206 tests, 0 failures, 1 skipped.
