### PR TITLE
Fix race condition when dynamically starting pool supervisors

### DIFF
--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -101,18 +101,23 @@ defmodule Finch.Pool.Manager do
   defp do_get_pool(registry_name, pool, start_pool?, opts) do
     pool_name = Finch.Pool.to_name(pool)
 
-    case Registry.lookup(registry_name, pool_name) do
+    case lookup_pool(registry_name, pool_name, opts) do
       [] when start_pool? ->
         maybe_start_pool(registry_name, pool, pool_name, opts)
 
       [] ->
         :not_found
 
-      [single] ->
-        single
+      pool ->
+        pool
+    end
+  end
 
-      [_ | _] = entries ->
-        select_pool(entries, opts[:pool_strategy])
+  defp lookup_pool(registry_name, pool_name, opts) do
+    case Registry.lookup(registry_name, pool_name) do
+      [] -> []
+      [single] -> single
+      [_ | _] = entries -> select_pool(entries, opts[:pool_strategy])
     end
   end
 
@@ -125,16 +130,12 @@ defmodule Finch.Pool.Manager do
   @spec maybe_start_pool(atom(), Finch.Pool.t(), term(), Access.t()) ::
           {pid(), module()} | :not_found | :not_ready
   defp maybe_start_pool(registry_name, pool, pool_name, opts) do
-    case Registry.lookup(supervisor_registry_name(registry_name), pool_name) do
-      [] ->
-        # No supervisor — pool not configured yet, create on demand
-        {:ok, config} = Registry.meta(registry_name, :config)
-        start_pool(pool, pool_name, config)
-        do_get_pool(registry_name, pool, false, opts)
+    {:ok, config} = Registry.meta(registry_name, :config)
+    start_pool(pool, pool_name, config)
 
-      [_ | _] ->
-        # Supervisor exists but no ready workers
-        :not_ready
+    case lookup_pool(registry_name, pool_name, opts) do
+      [] -> :not_ready
+      pool -> pool
     end
   end
 

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -148,13 +148,15 @@ defmodule FinchTest do
 
       expect_any(bypass)
 
-      Task.async_stream(
-        1..50,
-        fn _ -> Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name) end,
-        max_concurrency: 50
-      )
-      |> Stream.run()
+      results =
+        Task.async_stream(
+          1..50,
+          fn _ -> Finch.build(:get, endpoint(bypass)) |> Finch.request(finch_name) end,
+          max_concurrency: 50
+        )
+        |> Enum.to_list()
 
+      assert Enum.all?(results, &match?({:ok, {:ok, %Response{status: 200}}}, &1))
       assert get_pools(finch_name, pool(bypass)) |> length() == 5
     end
   end


### PR DESCRIPTION
Before, the request path did this:

1. Look for a ready pool worker in the pool registry.
2. If none exists, check the supervisor registry.
3. If a supervisor exists but no worker is registered yet, return :not_ready.

There was a race condition, since one process could be starting the supervisor, whilst another would see the supervisor exists before the workers had registered. This would result in a `:pool_not_available`.

To fix this, after `start_pool` returns, we look for the ready pool again.

This uses starting the pool supervisor under the DynamicSupervisor (in start_pool/3) as a synchronization point.

So the path is now:

1. Look for a ready pool worker in the poll registry.
2. If none exists and dynamic start is allowed, call start_pool/3 which calls DynamicSupervisor.start_child/2.
3. If another process already started it, OTP returns {:error, {:already_started, pid}}, which we already treat as :ok.

The test has been updated to assert all of the requests succeed, instead of just asserting pool count.