### PR TITLE
fix: ignore SSLKEYLOGFILE when set to an empty string

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -548,7 +548,8 @@ defmodule Finch do
       |> Keyword.put(:enable_push, false)
 
     ssl_key_log_file =
-      Keyword.get(conn_opts, :ssl_key_log_file) || System.get_env("SSLKEYLOGFILE")
+      (Keyword.get(conn_opts, :ssl_key_log_file) || System.get_env("SSLKEYLOGFILE"))
+      |> normalize_ssl_key_log_file()
 
     ssl_key_log_file_device = ssl_key_log_file && File.open!(ssl_key_log_file, [:append])
 
@@ -580,6 +581,16 @@ defmodule Finch do
       max_connection_age_jitter: valid[:http2][:max_connection_age_jitter]
     }
   end
+
+  defp normalize_ssl_key_log_file(value) when is_binary(value) do
+    if String.trim(value) == "" do
+      nil
+    else
+      value
+    end
+  end
+
+  defp normalize_ssl_key_log_file(value), do: value
 
   defp to_native(:infinity), do: :infinity
   defp to_native(time), do: System.convert_time_unit(time, :millisecond, :native)

--- a/test/finch/cast_pool_opts_test.exs
+++ b/test/finch/cast_pool_opts_test.exs
@@ -1,0 +1,86 @@
+defmodule Finch.CastPoolOptsTest do
+  use ExUnit.Case, async: false
+
+  describe "cast_pool_opts/1" do
+    test "treats empty SSLKEYLOGFILE as unset" do
+      with_ssl_key_log_file_env("", fn ->
+        assert {:ok, %{conn_opts: conn_opts}} = Finch.cast_pool_opts([])
+        assert Keyword.fetch!(conn_opts, :ssl_key_log_file_device) == nil
+      end)
+    end
+
+    test "treats whitespace-only SSLKEYLOGFILE as unset" do
+      with_ssl_key_log_file_env("   ", fn ->
+        assert {:ok, %{conn_opts: conn_opts}} = Finch.cast_pool_opts([])
+        assert Keyword.fetch!(conn_opts, :ssl_key_log_file_device) == nil
+      end)
+    end
+
+    test "opens SSLKEYLOGFILE when it contains a path" do
+      log_file = tmp_path("env-ssl-key-file.log")
+
+      with_ssl_key_log_file_env(log_file, fn ->
+        assert {:ok, %{conn_opts: conn_opts}} = Finch.cast_pool_opts([])
+        device = Keyword.fetch!(conn_opts, :ssl_key_log_file_device)
+
+        try do
+          assert device != nil
+        after
+          if device, do: File.close(device)
+          File.rm(log_file)
+        end
+      end)
+    end
+
+    test "treats empty explicit ssl_key_log_file as unset" do
+      log_file = tmp_path("env-ssl-key-file.log")
+
+      with_ssl_key_log_file_env(log_file, fn ->
+        try do
+          assert {:ok, %{conn_opts: conn_opts}} =
+                   Finch.cast_pool_opts(conn_opts: [ssl_key_log_file: ""])
+
+          assert Keyword.fetch!(conn_opts, :ssl_key_log_file_device) == nil
+          refute File.exists?(log_file)
+        after
+          File.rm(log_file)
+        end
+      end)
+    end
+
+    test "opens explicit ssl_key_log_file when it contains a path" do
+      env_log_file = tmp_path("env-ssl-key-file.log")
+      explicit_log_file = tmp_path("explicit-ssl-key-file.log")
+
+      with_ssl_key_log_file_env(env_log_file, fn ->
+        assert {:ok, %{conn_opts: conn_opts}} =
+                 Finch.cast_pool_opts(conn_opts: [ssl_key_log_file: explicit_log_file])
+
+        device = Keyword.fetch!(conn_opts, :ssl_key_log_file_device)
+
+        try do
+          assert device != nil
+          refute File.exists?(env_log_file)
+        after
+          if device, do: File.close(device)
+          File.rm(env_log_file)
+          File.rm(explicit_log_file)
+        end
+      end)
+    end
+  end
+
+  defp with_ssl_key_log_file_env(value, fun) do
+    System.put_env("SSLKEYLOGFILE", value)
+
+    try do
+      fun.()
+    after
+      System.delete_env("SSLKEYLOGFILE")
+    end
+  end
+
+  defp tmp_path(filename) do
+    Path.join(System.tmp_dir(), "finch-#{System.unique_integer([:positive])}-#{filename}")
+  end
+end


### PR DESCRIPTION
## Summary

When `SSLKEYLOGFILE` is set to an empty string, Finch no longer crashes at startup. A blank or whitespace-only value is now treated the same as unset, so no key-log device is opened and `Finch.start_link/1` succeeds.

## Why this matters

In Elixir an empty string is truthy, so the existing guard

```elixir
ssl_key_log_file_device = ssl_key_log_file && File.open!(ssl_key_log_file, [:append])
```

still ran `File.open!("")` and raised `could not open "": no such file or directory`. Some environments set `SSLKEYLOGFILE=""` globally, which silently broke every Finch-backed app (issue #376 reports hitting this while debugging a Phoenix outage).

The fix normalizes the resolved value in `valid_opts_to_map/1` so a blank or whitespace-only path collapses to `nil` before the `File.open!` guard. A real path still opens the device, and an explicit `:ssl_key_log_file` conn option still takes precedence over the env var. No public API change.

## Testing

Added `test/finch/cast_pool_opts_test.exs`, exercising `Finch.cast_pool_opts/1` without a live TLS connection:

- empty `SSLKEYLOGFILE` produces a `nil` device (no crash)
- whitespace-only `SSLKEYLOGFILE` is treated the same
- a real env path still opens the device
- an explicit empty `:ssl_key_log_file` conn option collapses to `nil`
- a real explicit path still opens the device

```
mix test test/finch/cast_pool_opts_test.exs
Result: 5 passed
```

`mix format --check-formatted` and `mix compile --warnings-as-errors` both pass.

Fixes #376
