### PR TITLE
Add Finch.start_link spec and Finch.pool_opt,pool_opts types

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -18,6 +18,7 @@ defmodule Finch do
   @pool_config_schema [
     protocols: [
       type: {:list, {:in, [:http1, :http2]}},
+      type_spec: quote(do: [:http1 | :http2]),
       doc: """
       The type of connections to support.
 
@@ -156,6 +157,8 @@ defmodule Finch do
     ]
   ]
 
+  @pool_schema NimbleOptions.new!(@pool_config_schema)
+
   @typedoc """
   The `:name` provided to Finch in `start_link/1`.
   """
@@ -214,6 +217,13 @@ defmodule Finch do
   Options used by request functions.
   """
   @type request_opts() :: [request_opt()]
+
+  @type pool_opt() :: unquote(NimbleOptions.option_typespec(@pool_schema))
+
+  @typedoc """
+  Options used to configure a pool in `start_link/1`.
+  """
+  @type pool_opts() :: [pool_opt()]
 
   @typedoc """
   Errors returned by Finch request functions.
@@ -368,6 +378,9 @@ defmodule Finch do
 
   #{NimbleOptions.docs(@pool_config_schema)}
   """
+  @spec start_link(opts) :: Supervisor.on_start()
+        when opts: [{:name, atom()} | {:pools, pools}],
+             pools: %{(pool_identifier() | :default) => pool_opts()}
   def start_link(opts) do
     name = finch_name!(opts)
     pools = Keyword.get(opts, :pools, []) |> pool_options!()


### PR DESCRIPTION
In Req I'm adding `Req.request(url, finch: opts)` where opts are _a combination_ of Finch.build, Finch.request, and Finch.start_link options, see https://github.com/wojtekmach/req/pull/542#issuecomment-4742745577.

I'd like to mention pool options by name in the docs because they can't be all mixed and matched (pool options cannot be given when using a named pool).

I _think_ this is the type of single list of options that's then distributed to the three buckets:

```elixir
[{:name, Finch.name()} | Finch.request_opt() | Finch.Request.build_opt()] |
  [Finch.pool_opt() | Finch.request_opt() | Finch.Request.build_opt()]
```

(I'm actually not sure if I'm gonna use above type in my docs because it's pretty complicated and so not sure if that useful.)