### PR TITLE
Optimize RoundRobin.select/2 pool selection strategy

### DIFF
--- a/lib/finch/pool/strategy/round_robin.ex
+++ b/lib/finch/pool/strategy/round_robin.ex
@@ -24,7 +24,7 @@ defmodule Finch.Pool.Strategy.RoundRobin do
   @impl Finch.Pool.Strategy
   def select(entries, counter) do
     idx = :atomics.add_get(counter, 1, 1)
-    next = rem(idx - 1, length(entries))
-    Enum.at(entries, next)
+    tuple = :erlang.list_to_tuple(entries)
+    elem(tuple, rem(idx - 1, tuple_size(tuple)))
   end
 end


### PR DESCRIPTION
Assisted-by: Antigravity CLI : Gemini Flash 3.5

~1.5x faster, uses more memory though

Bench:
```elixir
Mix.install([{:benchee, "~> 1.0"}])

defmodule Original do
  def select(entries, counter) do
    idx = :atomics.add_get(counter, 1, 1)
    next = rem(idx - 1, length(entries))
    Enum.at(entries, next)
  end
end

defmodule Optimized do
  def select(entries, counter) do
    idx = :atomics.add_get(counter, 1, 1)
    tuple = :erlang.list_to_tuple(entries)
    elem(tuple, rem(idx - 1, tuple_size(tuple)))
  end
end

inputs = %{
  "Small Pool (2 entries)" => {Enum.map(1..2, fn i -> {:worker, i} end), :atomics.new(1, [])},
  "Medium Pool (10 entries)" => {Enum.map(1..10, fn i -> {:worker, i} end), :atomics.new(1, [])},
  "Large Pool (50 entries)" => {Enum.map(1..50, fn i -> {:worker, i} end), :atomics.new(1, [])}
}

Benchee.run(
  %{
    "original_select" => fn {entries, counter} ->
      Original.select(entries, counter)
    end,
    "optimized_select" => fn {entries, counter} ->
      Optimized.select(entries, counter)
    end
  },
  inputs: inputs,
  time: 2,
  memory_time: 1,
  pre_check: true
)
```

Bech results on noisy machine:

```txt
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.1
Erlang 29.0.2
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 s
memory time: 1 s
reduction time: 0 ns
parallel: 1
inputs: Large Pool (50 entries), Medium Pool (10 entries), Small Pool (2 entries)
Estimated total run time: 30 s
Excluding outliers: false

##### With input Large Pool (50 entries) #####
Name                       ips        average  deviation         median         99th %
optimized_select        9.72 M      102.85 ns  ±3473.15%          91 ns         150 ns
original_select         7.04 M      142.09 ns   ±294.15%         140 ns         250 ns

Comparison:
optimized_select        9.72 M
original_select         7.04 M - 1.38x slower +39.23 ns

Memory usage statistics:

Name                Memory usage
optimized_select           408 B
original_select             16 B - 0.04x memory usage -392 B

**All measurements for memory usage were the same**

##### With input Medium Pool (10 entries) #####
Name                       ips        average  deviation         median         99th %
optimized_select       20.27 M       49.33 ns   ±259.72%          50 ns          70 ns
original_select        12.47 M       80.21 ns  ±5833.26%          70 ns         120 ns

Comparison:
optimized_select       20.27 M
original_select        12.47 M - 1.63x slower +30.88 ns

Memory usage statistics:

Name                Memory usage
optimized_select            88 B
original_select             16 B - 0.18x memory usage -72 B

**All measurements for memory usage were the same**

##### With input Small Pool (2 entries) #####
Name                       ips        average  deviation         median         99th %
optimized_select       20.67 M       48.38 ns  ±5322.28%          40 ns          70 ns
original_select        13.67 M       73.16 ns  ±6565.96%          60 ns         100 ns

Comparison:
optimized_select       20.67 M
original_select        13.67 M - 1.51x slower +24.77 ns

Memory usage statistics:

Name                Memory usage
optimized_select            24 B
original_select             16 B - 0.67x memory usage -8 B

**All measurements for memory usage were the same**
```