### PR TITLE
Fixes an HTTP2 bug that arises when a server responds early

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -794,7 +794,7 @@ defmodule Finch.HTTP2.Pool do
 
     if request do
       send(request.from_pid, {request.request_ref, :done})
-      Telemetry.stop(:recv, request.telemetry.recv, request.telemetry.metadata)
+      stop_response_telemetry(request)
     end
 
     {data, [cancel_request_timeout_action(ref) | actions]}
@@ -818,15 +818,25 @@ defmodule Finch.HTTP2.Pool do
     if request do
       wrapped_error = Error.wrap(error)
       send(request.from_pid, {request.request_ref, {:error, wrapped_error}})
-
-      Telemetry.stop(
-        :recv,
-        request.telemetry.recv,
-        Map.put(request.telemetry.metadata, :error, wrapped_error)
-      )
+      stop_response_telemetry(request, %{error: wrapped_error})
     end
 
     {data, [cancel_request_timeout_action(ref) | actions]}
+  end
+
+  # The server may send a terminal response before the client finishes
+  # streaming its own request body (e.g. an early 413 rejection) this is
+  # valid, spec-sanctioned HTTP/2 behavior (RFC 9113). In that case `:recv`
+  # was never started, since it's only set in `complete_request_if_done/3`
+  # once sending completes. Stop whichever span actually started instead of
+  # assuming `:recv` exists, to avoid `KeyError: key :recv not found`.
+  defp stop_response_telemetry(request, extra_metadata \\ %{}) do
+    metadata = Map.merge(request.telemetry.metadata, extra_metadata)
+
+    case request.telemetry do
+      %{recv: recv_start} -> Telemetry.stop(:recv, recv_start, metadata)
+      %{send: send_start} -> Telemetry.stop(:send, send_start, metadata)
+    end
   end
 
   defp cancel_request_timeout_action(request_ref) do

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -82,6 +82,52 @@ defmodule Finch.HTTP2.PoolTest do
       assert_receive {:resp, {:ok, {200, [], "hello to you"}}}
     end
 
+    test "keeps the pool alive when the server ends a response before upload completes", %{
+      request: req
+    } do
+      {:ok, pool} =
+        start_server_and_connect_with(fn port ->
+          start_pool(port)
+        end)
+
+      request = %{
+        req
+        | method: "POST",
+          body: {:stream, Stream.repeatedly(fn -> String.duplicate("x", 16_384) end)}
+      }
+
+      request_ref = Pool.async_request(pool, request, nil, [])
+
+      # The initial HTTP/2 flow-control window permits only part of this
+      # unbounded body, leaving the request's :send span active.
+      assert [headers(stream_id: stream_id)] = recv_next_frames(1)
+
+      assert_recv_frames([
+        data(stream_id: ^stream_id),
+        data(stream_id: ^stream_id),
+        data(stream_id: ^stream_id),
+        data(stream_id: ^stream_id)
+      ])
+
+      assert {_, %{requests: requests}} = :sys.get_state(pool)
+      assert [%{telemetry: telemetry}] = Map.values(requests)
+      refute Map.has_key?(telemetry, :recv)
+
+      server_send_frames([
+        headers(
+          stream_id: stream_id,
+          hbf: server_encode_headers([{":status", "413"}]),
+          flags: set_flags(:headers, [:end_headers, :end_stream])
+        )
+      ])
+
+      assert_receive {^request_ref, {:status, 413}}
+      assert_receive {^request_ref, {:headers, []}}
+      assert_receive {^request_ref, :done}
+      assert {_, %{requests: %{}}} = :sys.get_state(pool)
+      assert Process.alive?(pool)
+    end
+
     test "errors such as :max_header_list_size_reached are returned to the caller", %{
       request: req
     } do


### PR DESCRIPTION
In http2 if a server responds early with a 413 as the payload is being sent then :recv is never started. Subsequently when it is referenced it causes a crash.

This fixes the issue by adding some detection before we stop telemetry to see what state we are in.