### PR TITLE
Fix `MatchError` when cancelling while HTTP/2 pool is `disconnected`

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -322,7 +322,7 @@ defmodule Finch.HTTP2.Pool do
 
   # Ignore cancel requests if we are disconnected
   def disconnected({:call, from}, {:cancel, _request_ref}, _data) do
-    {:keep_state_and_data, {:reply, from, {:error, Error.exception(:disconnected)}}}
+    {:keep_state_and_data, {:reply, from, :ok}}
   end
 
   def disconnected({:call, from}, :ping, _data) do

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -429,6 +429,21 @@ defmodule Finch.HTTP2.PoolTest do
       assert refs == %{}
     end
 
+    test "cancel_async_request/1 returns :ok when the pool is disconnected", %{request: req} do
+      {:ok, pool} =
+        start_server_and_connect_with(fn port ->
+          start_pool(port)
+        end)
+
+      ref = Pool.async_request(pool, req, self(), [])
+
+      # Force the connection to disconnect.
+      :ok = :ssl.close(server_socket())
+      Process.sleep(50)
+
+      assert :ok = Pool.cancel_async_request(ref)
+    end
+
     test "if server sends GOAWAY and then replies, we get the replies but are closed for writing",
          %{request: req} do
       {:ok, pool} =


### PR DESCRIPTION
We've spotted a few of these uncaught `MatchError`s recently in one of our production systems that uses an HTTP/2 pool. The stack trace led me to line 64 (88 also affected) and I took a stab at it.

The `disconnected` state replied with an error tuple to `{:cancel, ref}` calls, but both callers (`request` and `async_request`) pattern-match strictly on `:ok`, causing a `MatchError`. Now we reply with `:ok`, consistent with the other three states.

Worth noting that raising a `MatchError` at that point prevented `clean_responses` from being called, which could possibly cause pileups in the process mailbox and other sorts of abnormal behavior.