### PR TITLE
Fix first request to dynamically started HTTP/2 pools

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -855,8 +855,8 @@ defmodule Finch do
 
   ## Options
 
-    * `:pool_timeout` - This timeout is applied when we check out a connection from the pool.
-      Default value is `5_000`.
+    * `:pool_timeout` - The maximum time to wait for a dynamically started pool to become
+      available and, for HTTP/1, to check out a connection from the pool. Default value is `5_000`.
 
     * `:receive_timeout` - The maximum time to wait for each chunk to be received before returning an error.
       Default value is `15_000`.

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -857,6 +857,7 @@ defmodule Finch do
 
     * `:pool_timeout` - The maximum time to wait for a dynamically started pool to become
       available and, for HTTP/1, to check out a connection from the pool. Default value is `5_000`.
+      Setting it to `:infinity` may block forever if no pool or connection becomes available.
 
     * `:receive_timeout` - The maximum time to wait for each chunk to be received before returning an error.
       Default value is `15_000`.

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -147,6 +147,9 @@ defmodule Finch.HTTP1.Pool do
   @impl Finch.Pool.Manager
   defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
+  @impl Finch.Pool.Manager
+  def ready?(_pool), do: true
+
   @impl NimblePool
   def init_pool({pool, pool_name, registry, pool_config, pool_idx}) do
     {:ok, metric_ref} =

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -148,7 +148,7 @@ defmodule Finch.HTTP1.Pool do
   defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
   @impl Finch.Pool.Manager
-  def ready?(_pool), do: true
+  def ready?(_pool, _timeout), do: true
 
   @impl NimblePool
   def init_pool({pool, pool_name, registry, pool_config, pool_idx}) do

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -92,6 +92,13 @@ defmodule Finch.HTTP2.Pool do
   @impl Finch.Pool.Manager
   defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
+  @impl Finch.Pool.Manager
+  def ready?(pool) do
+    :gen_statem.call(pool, :ready?)
+  catch
+    :exit, _reason -> false
+  end
+
   defp make_request_ref(pool) do
     {__MODULE__, {pool, make_ref()}}
   end
@@ -237,6 +244,10 @@ defmodule Finch.HTTP2.Pool do
     :keep_state_and_data
   end
 
+  def disconnected({:call, from}, :ready?, _data) do
+    {:keep_state_and_data, {:reply, from, false}}
+  end
+
   # When entering a disconnected state we need to fail all of the pending
   # requests
   def disconnected(:enter, _, data) do
@@ -368,6 +379,10 @@ defmodule Finch.HTTP2.Pool do
 
   def connecting(:enter, _old_state, _data), do: :keep_state_and_data
 
+  def connecting({:call, from}, :ready?, _data) do
+    {:keep_state_and_data, {:reply, from, false}}
+  end
+
   def connecting({:call, from}, {:request, _, _, _}, _data),
     do: {:keep_state_and_data, {:reply, from, {:error, Error.exception(:connection_not_ready)}}}
 
@@ -419,6 +434,10 @@ defmodule Finch.HTTP2.Pool do
     {:ok, _} = Registry.register(data.finch_name, data.pool_name, __MODULE__)
     update_max_concurrent_streams(data)
     {:keep_state_and_data, [ping_action(data) | connection_age_action(data)]}
+  end
+
+  def connected({:call, from}, :ready?, _data) do
+    {:keep_state_and_data, {:reply, from, true}}
   end
 
   # Issue request to the upstream server. We store a ref to the request so we
@@ -576,6 +595,10 @@ defmodule Finch.HTTP2.Pool do
       end)
 
     {:keep_state, data}
+  end
+
+  def connected_read_only({:call, from}, :ready?, _data) do
+    {:keep_state_and_data, {:reply, from, false}}
   end
 
   # If we're in a read only state then respond with an error immediately

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -93,10 +93,29 @@ defmodule Finch.HTTP2.Pool do
   defdelegate get_pool_status(finch_name, pool_name), to: PoolMetrics
 
   @impl Finch.Pool.Manager
-  def ready?(pool) do
-    :gen_statem.call(pool, :ready?)
-  catch
-    :exit, _reason -> false
+  def ready?(pool, timeout) do
+    ref = make_ref()
+
+    try do
+      :gen_statem.call(pool, {:ready?, ref}, timeout)
+    catch
+      :exit, _reason ->
+        :gen_statem.cast(pool, {:cancel_ready, ref})
+        false
+    end
+  end
+
+  defp await_ready(data, ref, from) do
+    update_in(data.awaiting_ready, &[{ref, from} | &1])
+  end
+
+  defp cancel_ready(data, ref) do
+    update_in(data.awaiting_ready, &List.keydelete(&1, ref, 0))
+  end
+
+  defp reply_to_awaiting_ready(data) do
+    Enum.each(data.awaiting_ready, fn {_ref, from} -> :gen_statem.reply(from, true) end)
+    %{data | awaiting_ready: []}
   end
 
   defp make_request_ref(pool) do
@@ -222,6 +241,7 @@ defmodule Finch.HTTP2.Pool do
       requests: %{},
       refs: %{},
       requests_by_pid: %{},
+      awaiting_ready: [],
       backoff_base: @backoff_base,
       backoff_max: @backoff_max,
       connect_opts: pool_config.conn_opts,
@@ -244,8 +264,12 @@ defmodule Finch.HTTP2.Pool do
     :keep_state_and_data
   end
 
-  def disconnected({:call, from}, :ready?, _data) do
-    {:keep_state_and_data, {:reply, from, false}}
+  def disconnected({:call, from}, {:ready?, ref}, data) do
+    {:keep_state, await_ready(data, ref, from)}
+  end
+
+  def disconnected(:cast, {:cancel_ready, ref}, data) do
+    {:keep_state, cancel_ready(data, ref)}
   end
 
   # When entering a disconnected state we need to fail all of the pending
@@ -379,8 +403,12 @@ defmodule Finch.HTTP2.Pool do
 
   def connecting(:enter, _old_state, _data), do: :keep_state_and_data
 
-  def connecting({:call, from}, :ready?, _data) do
-    {:keep_state_and_data, {:reply, from, false}}
+  def connecting({:call, from}, {:ready?, ref}, data) do
+    {:keep_state, await_ready(data, ref, from)}
+  end
+
+  def connecting(:cast, {:cancel_ready, ref}, data) do
+    {:keep_state, cancel_ready(data, ref)}
   end
 
   def connecting({:call, from}, {:request, _, _, _}, _data),
@@ -433,11 +461,16 @@ defmodule Finch.HTTP2.Pool do
   def connected(:enter, _old_state, data) do
     {:ok, _} = Registry.register(data.finch_name, data.pool_name, __MODULE__)
     update_max_concurrent_streams(data)
-    {:keep_state_and_data, [ping_action(data) | connection_age_action(data)]}
+    data = reply_to_awaiting_ready(data)
+    {:keep_state, data, [ping_action(data) | connection_age_action(data)]}
   end
 
-  def connected({:call, from}, :ready?, _data) do
+  def connected({:call, from}, {:ready?, _ref}, _data) do
     {:keep_state_and_data, {:reply, from, true}}
+  end
+
+  def connected(:cast, {:cancel_ready, _ref}, _data) do
+    :keep_state_and_data
   end
 
   # Issue request to the upstream server. We store a ref to the request so we
@@ -597,8 +630,12 @@ defmodule Finch.HTTP2.Pool do
     {:keep_state, data}
   end
 
-  def connected_read_only({:call, from}, :ready?, _data) do
+  def connected_read_only({:call, from}, {:ready?, _ref}, _data) do
     {:keep_state_and_data, {:reply, from, false}}
+  end
+
+  def connected_read_only(:cast, {:cancel_ready, _ref}, _data) do
+    :keep_state_and_data
   end
 
   # If we're in a read only state then respond with an error immediately

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -94,27 +94,18 @@ defmodule Finch.HTTP2.Pool do
 
   @impl Finch.Pool.Manager
   def ready?(pool, timeout) do
-    ref = make_ref()
-
-    try do
-      :gen_statem.call(pool, {:ready?, ref}, timeout)
-    catch
-      :exit, _reason ->
-        :gen_statem.cast(pool, {:cancel_ready, ref})
-        false
-    end
+    :gen_statem.call(pool, :ready?, timeout)
+  catch
+    :exit, {:timeout, _} -> false
+    :exit, _reason -> :retry
   end
 
-  defp await_ready(data, ref, from) do
-    update_in(data.awaiting_ready, &[{ref, from} | &1])
-  end
-
-  defp cancel_ready(data, ref) do
-    update_in(data.awaiting_ready, &List.keydelete(&1, ref, 0))
+  defp await_ready(data, from) do
+    update_in(data.awaiting_ready, &[from | &1])
   end
 
   defp reply_to_awaiting_ready(data) do
-    Enum.each(data.awaiting_ready, fn {_ref, from} -> :gen_statem.reply(from, true) end)
+    Enum.each(data.awaiting_ready, &:gen_statem.reply(&1, true))
     %{data | awaiting_ready: []}
   end
 
@@ -264,12 +255,8 @@ defmodule Finch.HTTP2.Pool do
     :keep_state_and_data
   end
 
-  def disconnected({:call, from}, {:ready?, ref}, data) do
-    {:keep_state, await_ready(data, ref, from)}
-  end
-
-  def disconnected(:cast, {:cancel_ready, ref}, data) do
-    {:keep_state, cancel_ready(data, ref)}
+  def disconnected({:call, from}, :ready?, data) do
+    {:keep_state, await_ready(data, from)}
   end
 
   # When entering a disconnected state we need to fail all of the pending
@@ -403,12 +390,8 @@ defmodule Finch.HTTP2.Pool do
 
   def connecting(:enter, _old_state, _data), do: :keep_state_and_data
 
-  def connecting({:call, from}, {:ready?, ref}, data) do
-    {:keep_state, await_ready(data, ref, from)}
-  end
-
-  def connecting(:cast, {:cancel_ready, ref}, data) do
-    {:keep_state, cancel_ready(data, ref)}
+  def connecting({:call, from}, :ready?, data) do
+    {:keep_state, await_ready(data, from)}
   end
 
   def connecting({:call, from}, {:request, _, _, _}, _data),
@@ -465,12 +448,8 @@ defmodule Finch.HTTP2.Pool do
     {:keep_state, data, [ping_action(data) | connection_age_action(data)]}
   end
 
-  def connected({:call, from}, {:ready?, _ref}, _data) do
+  def connected({:call, from}, :ready?, _data) do
     {:keep_state_and_data, {:reply, from, true}}
-  end
-
-  def connected(:cast, {:cancel_ready, _ref}, _data) do
-    :keep_state_and_data
   end
 
   # Issue request to the upstream server. We store a ref to the request so we
@@ -630,12 +609,8 @@ defmodule Finch.HTTP2.Pool do
     {:keep_state, data}
   end
 
-  def connected_read_only({:call, from}, {:ready?, _ref}, _data) do
+  def connected_read_only({:call, from}, :ready?, _data) do
     {:keep_state_and_data, {:reply, from, false}}
-  end
-
-  def connected_read_only(:cast, {:cancel_ready, _ref}, _data) do
-    :keep_state_and_data
   end
 
   # If we're in a read only state then respond with an error immediately

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -36,6 +36,9 @@ defmodule Finch.Pool.Manager do
               {:ok, list(map)} | {:error, :not_found}
 
   @doc false
+  @callback ready?(pid()) :: boolean()
+
+  @doc false
   defguard is_request_ref(ref) when tuple_size(ref) == 2 and is_atom(elem(ref, 0))
 
   @type config() :: %{
@@ -131,11 +134,26 @@ defmodule Finch.Pool.Manager do
           {pid(), module()} | :not_found | :not_ready
   defp maybe_start_pool(registry_name, pool, pool_name, opts) do
     {:ok, config} = Registry.meta(registry_name, :config)
-    start_pool(pool, pool_name, config)
+    {pool_supervisor, pool_mod} = start_pool(pool, pool_name, config)
 
     case lookup_pool(registry_name, pool_name, opts) do
-      [] -> :not_ready
-      pool -> pool
+      [] ->
+        wait_for_pool_initialization(pool_supervisor, pool_mod)
+
+        case lookup_pool(registry_name, pool_name, opts) do
+          [] -> :not_ready
+          pool -> pool
+        end
+
+      pool ->
+        pool
+    end
+  end
+
+  defp wait_for_pool_initialization(pool_supervisor, pool_mod) do
+    case Supervisor.which_children(pool_supervisor) do
+      [{_id, pool, :worker, _modules} | _] when is_pid(pool) -> pool_mod.ready?(pool)
+      _ -> false
     end
   end
 
@@ -224,8 +242,8 @@ defmodule Finch.Pool.Manager do
     )
     # In case of races, it will return it has already been started
     |> case do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
+      {:ok, pid} -> {pid, pool_config.mod}
+      {:error, {:already_started, pid}} -> {pid, pool_config.mod}
     end
   end
 

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -2,6 +2,8 @@ defmodule Finch.Pool.Manager do
   @moduledoc false
   use GenServer
 
+  @default_pool_timeout 5_000
+
   @typedoc false
   @type request_ref :: {pool_mod :: module(), cancel_ref :: term()}
 
@@ -36,7 +38,7 @@ defmodule Finch.Pool.Manager do
               {:ok, list(map)} | {:error, :not_found}
 
   @doc false
-  @callback ready?(pid()) :: boolean()
+  @callback ready?(pid(), timeout()) :: boolean()
 
   @doc false
   defguard is_request_ref(ref) when tuple_size(ref) == 2 and is_atom(elem(ref, 0))
@@ -138,7 +140,8 @@ defmodule Finch.Pool.Manager do
 
     case lookup_pool(registry_name, pool_name, opts) do
       [] ->
-        wait_for_pool_initialization(pool_supervisor, pool_mod)
+        timeout = Access.get(opts, :pool_timeout, @default_pool_timeout)
+        wait_for_pool_initialization(pool_supervisor, pool_mod, timeout)
 
         case lookup_pool(registry_name, pool_name, opts) do
           [] -> :not_ready
@@ -150,9 +153,9 @@ defmodule Finch.Pool.Manager do
     end
   end
 
-  defp wait_for_pool_initialization(pool_supervisor, pool_mod) do
+  defp wait_for_pool_initialization(pool_supervisor, pool_mod, timeout) do
     case Supervisor.which_children(pool_supervisor) do
-      [{_id, pool, :worker, _modules} | _] when is_pid(pool) -> pool_mod.ready?(pool)
+      [{_id, pool, :worker, _modules} | _] when is_pid(pool) -> pool_mod.ready?(pool, timeout)
       _ -> false
     end
   end

--- a/lib/finch/pool/manager.ex
+++ b/lib/finch/pool/manager.ex
@@ -38,7 +38,7 @@ defmodule Finch.Pool.Manager do
               {:ok, list(map)} | {:error, :not_found}
 
   @doc false
-  @callback ready?(pid(), timeout()) :: boolean()
+  @callback ready?(pid(), timeout()) :: boolean() | :retry
 
   @doc false
   defguard is_request_ref(ref) when tuple_size(ref) == 2 and is_atom(elem(ref, 0))
@@ -141,7 +141,13 @@ defmodule Finch.Pool.Manager do
     case lookup_pool(registry_name, pool_name, opts) do
       [] ->
         timeout = Access.get(opts, :pool_timeout, @default_pool_timeout)
-        wait_for_pool_initialization(pool_supervisor, pool_mod, timeout)
+
+        deadline =
+          if timeout == :infinity,
+            do: :infinity,
+            else: System.monotonic_time(:millisecond) + timeout
+
+        wait_for_pool_initialization(pool_supervisor, pool_mod, deadline)
 
         case lookup_pool(registry_name, pool_name, opts) do
           [] -> :not_ready
@@ -153,10 +159,30 @@ defmodule Finch.Pool.Manager do
     end
   end
 
-  defp wait_for_pool_initialization(pool_supervisor, pool_mod, timeout) do
-    case Supervisor.which_children(pool_supervisor) do
-      [{_id, pool, :worker, _modules} | _] when is_pid(pool) -> pool_mod.ready?(pool, timeout)
-      _ -> false
+  defp wait_for_pool_initialization(pool_supervisor, pool_mod, deadline) do
+    child =
+      Enum.find(Supervisor.which_children(pool_supervisor), fn
+        {_id, pool, :worker, _modules} when is_pid(pool) -> true
+        _ -> false
+      end)
+
+    timeout =
+      if deadline == :infinity,
+        do: :infinity,
+        else: max(deadline - System.monotonic_time(:millisecond), 0)
+
+    case child do
+      {_id, pool, :worker, _modules} ->
+        case pool_mod.ready?(pool, timeout) do
+          :retry when timeout != 0 ->
+            wait_for_pool_initialization(pool_supervisor, pool_mod, deadline)
+
+          ready? ->
+            ready?
+        end
+
+      nil ->
+        false
     end
   end
 

--- a/test/finch/http2/integration_test.exs
+++ b/test/finch/http2/integration_test.exs
@@ -29,6 +29,45 @@ defmodule Finch.HTTP2.IntegrationTest do
     assert response.body == "Hello world!"
   end
 
+  test "sends the first request through a dynamically started pool", %{url: url} do
+    start_supervised!(
+      {Finch,
+       name: TestFinch,
+       pools: %{
+         default: [
+           protocols: [:http2],
+           conn_opts: [transport_opts: [verify: :verify_none]]
+         ]
+       }}
+    )
+
+    assert {:ok, response} = Finch.build(:get, url) |> Finch.request(TestFinch)
+    assert response.body == "Hello world!"
+  end
+
+  test "sends concurrent first requests through a dynamically started pool", %{url: url} do
+    start_supervised!(
+      {Finch,
+       name: TestFinch,
+       pools: %{
+         default: [
+           protocols: [:http2],
+           conn_opts: [transport_opts: [verify: :verify_none]]
+         ]
+       }}
+    )
+
+    results =
+      Task.async_stream(
+        1..10,
+        fn _ -> Finch.build(:get, url) |> Finch.request(TestFinch) end,
+        max_concurrency: 10
+      )
+      |> Enum.to_list()
+
+    assert Enum.all?(results, &match?({:ok, {:ok, %Finch.Response{status: 200}}}, &1))
+  end
+
   test "sends the query string", %{url: url} do
     TestHelper.start_finch!(
       name: TestFinch,

--- a/test/finch/http2/integration_test.exs
+++ b/test/finch/http2/integration_test.exs
@@ -1,6 +1,7 @@
 defmodule Finch.HTTP2.IntegrationTest do
   use ExUnit.Case, async: false
 
+  alias Finch.MockHTTP2Server
   alias Finch.TestHelper
 
   @moduletag :capture_log
@@ -66,6 +67,50 @@ defmodule Finch.HTTP2.IntegrationTest do
       |> Enum.to_list()
 
     assert Enum.all?(results, &match?({:ok, {:ok, %Finch.Response{status: 200}}}, &1))
+  end
+
+  test "releases all callers when a dynamically started pool receives server settings" do
+    start_finch_waiting_for_server_settings!()
+
+    {request_tasks, server} =
+      MockHTTP2Server.start_and_connect_with([defer_settings: true], fn port ->
+        pool = Finch.Pool.new("https://localhost:#{port}")
+
+        Enum.map(1..10, fn _ ->
+          Task.async(fn ->
+            Finch.Pool.Manager.get_pool(TestFinch, pool, pool_timeout: 1_000)
+          end)
+        end)
+      end)
+
+    Enum.each(request_tasks, fn task -> refute Task.yield(task, 20) end)
+    :ok = MockHTTP2Server.send_server_settings(server)
+
+    Enum.each(request_tasks, fn task ->
+      assert {pool, Finch.HTTP2.Pool} = Task.await(task, 1_000)
+      assert is_pid(pool)
+    end)
+  end
+
+  test "times out waiting for a dynamically started pool" do
+    start_finch_waiting_for_server_settings!()
+
+    {request_task, _server} =
+      MockHTTP2Server.start_and_connect_with([defer_settings: true], fn port ->
+        request = Finch.build(:get, "https://localhost:#{port}")
+
+        Task.async(fn ->
+          started = System.monotonic_time(:millisecond)
+          result = Finch.request(request, TestFinch, pool_timeout: 50)
+          elapsed = System.monotonic_time(:millisecond) - started
+          {result, elapsed}
+        end)
+      end)
+
+    assert {{:error, %Finch.Error{reason: :pool_not_available}}, elapsed} =
+             Task.await(request_task, 1_000)
+
+    assert elapsed >= 40
   end
 
   test "sends the query string", %{url: url} do
@@ -219,5 +264,19 @@ defmodule Finch.HTTP2.IntegrationTest do
            ) == :error
 
     refute_receive _
+  end
+
+  defp start_finch_waiting_for_server_settings! do
+    start_supervised!(
+      {Finch,
+       name: TestFinch,
+       pools: %{
+         default: [
+           protocols: [:http2],
+           conn_opts: [transport_opts: [verify: :verify_none]],
+           http2: [wait_for_server_settings?: true]
+         ]
+       }}
+    )
   end
 end

--- a/test/finch/http2/integration_test.exs
+++ b/test/finch/http2/integration_test.exs
@@ -113,6 +113,55 @@ defmodule Finch.HTTP2.IntegrationTest do
     assert elapsed >= 40
   end
 
+  for timeout <- [1_000, :infinity] do
+    test "waits for a replacement pool with pool_timeout #{inspect(timeout)}" do
+      start_finch_waiting_for_server_settings!()
+
+      {{task, pool}, server} =
+        MockHTTP2Server.start_and_connect_with([defer_settings: true], fn port ->
+          pool = Finch.Pool.new("https://localhost:#{port}")
+
+          task =
+            Task.async(fn ->
+              Finch.Pool.Manager.get_pool(TestFinch, pool, pool_timeout: unquote(timeout))
+            end)
+
+          {task, pool}
+        end)
+
+      old_pool = waiting_pool(pool)
+      Process.exit(old_pool, :kill)
+      _server = MockHTTP2Server.accept_socket(server)
+
+      assert {new_pool, Finch.HTTP2.Pool} = Task.await(task, 500)
+      assert new_pool != old_pool
+    end
+  end
+
+  test "pool restarts do not reset the readiness timeout" do
+    start_finch_waiting_for_server_settings!()
+
+    {{task, pool}, _server} =
+      MockHTTP2Server.start_and_connect_with([defer_settings: true], fn port ->
+        pool = Finch.Pool.new("https://localhost:#{port}")
+
+        task =
+          Task.async(fn ->
+            Finch.Pool.Manager.get_pool(TestFinch, pool, pool_timeout: 1_000)
+          end)
+
+        {task, pool}
+      end)
+
+    old_pool = waiting_pool(pool)
+    refute Task.yield(task, 750)
+    Process.exit(old_pool, :kill)
+
+    # Leave the replacement waiting for its handshake. Only the time remaining
+    # from the original timeout should be available to it.
+    assert :not_ready = Task.await(task, 500)
+  end
+
   test "sends the query string", %{url: url} do
     TestHelper.start_finch!(
       name: TestFinch,
@@ -264,6 +313,30 @@ defmodule Finch.HTTP2.IntegrationTest do
            ) == :error
 
     refute_receive _
+  end
+
+  defp waiting_pool(pool) do
+    {supervisor, _, _, _, _} = Finch.Pool.Manager.get_pool_supervisor(TestFinch, pool)
+    [{_, pid, _, _}] = Supervisor.which_children(supervisor)
+
+    assert eventually(fn ->
+             {_, data} = :sys.get_state(pid)
+             length(data.awaiting_ready) == 1
+           end)
+
+    pid
+  end
+
+  defp eventually(fun, attempts \\ 100)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(5)
+      eventually(fun, attempts - 1)
+    end
   end
 
   defp start_finch_waiting_for_server_settings! do

--- a/test/finch/http2/pool_test.exs
+++ b/test/finch/http2/pool_test.exs
@@ -223,6 +223,82 @@ defmodule Finch.HTTP2.PoolTest do
       assert_receive {:result, {:ok, {200, [], "ok"}}}
     end
 
+    test "ready? returns immediately when the pool is connected" do
+      {:ok, pool} =
+        start_server_and_connect_with(fn port -> start_pool(port) end)
+
+      assert Pool.ready?(pool, 100)
+    end
+
+    test "ready? tolerates exited callers when the pool connects" do
+      {:ok, pool} =
+        start_server_and_connect_with(
+          [assert_registered: false, defer_settings: true],
+          fn port -> start_pool(port, wait_for_server_settings?: true) end
+        )
+
+      {caller, ref} = spawn_monitor(fn -> Pool.ready?(pool, :infinity) end)
+
+      assert eventually(fn -> ready_waiter_count(pool) == 1 end)
+      Process.exit(caller, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^caller, :killed}
+
+      server_send_settings()
+      assert_registered()
+      assert ready_waiter_count(pool) == 0
+      assert Pool.ready?(pool, 100)
+    end
+
+    test "ready? clears timed-out waiters when the pool connects" do
+      {:ok, pool} =
+        start_server_and_connect_with(
+          [assert_registered: false, defer_settings: true],
+          fn port -> start_pool(port, wait_for_server_settings?: true) end
+        )
+
+      monitors = Process.info(self(), :monitors)
+      refute Pool.ready?(pool, 10)
+      assert Process.info(self(), :monitors) == monitors
+
+      server_send_settings()
+      assert_registered()
+      assert ready_waiter_count(pool) == 0
+    end
+
+    test "ready? retries dead pools without consuming unrelated monitor messages" do
+      {pool, ref} = spawn_monitor(fn -> :ok end)
+      assert_receive {:DOWN, ^ref, :process, ^pool, :normal} = down
+      send(self(), down)
+      monitors = Process.info(self(), :monitors)
+
+      assert :retry = Pool.ready?(pool, 100)
+      assert_receive ^down
+      assert Process.info(self(), :monitors) == monitors
+    end
+
+    test "ready? does not leave late replies in the caller mailbox" do
+      {:ok, pool} = start_server_and_connect_with(fn port -> start_pool(port) end)
+      :sys.suspend(pool)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          result = Pool.ready?(pool, 10)
+          send(parent, :timed_out)
+
+          receive do
+            :inspect -> {result, Process.info(self(), :messages), Process.info(self(), :monitors)}
+          end
+        end)
+
+      assert_receive :timed_out
+      :sys.resume(pool)
+      :sys.get_state(pool)
+      send(task.pid, :inspect)
+
+      assert {false, {:messages, []}, {:monitors, []}} = Task.await(task)
+    end
+
     test "request timeout with timeout of 0", %{request: req} do
       us = self()
 
@@ -896,6 +972,23 @@ defmodule Finch.HTTP2.PoolTest do
     end
 
     Pool.request(pool, req, acc, fun, nil, opts)
+  end
+
+  defp ready_waiter_count(pool) do
+    {_state, data} = :sys.get_state(pool)
+    length(data.awaiting_ready)
+  end
+
+  defp eventually(fun, attempts \\ 100)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(1)
+      eventually(fun, attempts - 1)
+    end
   end
 
   defp start_server_and_connect_with(opts \\ [], fun) do


### PR DESCRIPTION
Wait for the initial connection attempt before rechecking the pool registry, preventing transient :pool_not_available errors for first and concurrent requests.

cc @mtrudel 